### PR TITLE
Increase nav logo size

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
       radial-gradient(0.9px 0.9px at 80% 85%, rgba(253,230,138,0.5) 0%, transparent 100%);
   }
   nav { position:fixed; top:0; left:0; right:0; z-index:100; padding:1.2rem 3rem; display:flex; align-items:center; justify-content:space-between; background:rgba(8,4,22,0.85); backdrop-filter:blur(12px); }
-  .nav-logo { font-family:'Cormorant Garamond',serif; font-size:1.2rem; font-weight:300; letter-spacing:0.12em; color:var(--star); text-decoration:none; cursor:pointer; }
+  .nav-logo { font-family:'Cormorant Garamond',serif; font-size:1.6rem; font-weight:300; letter-spacing:0.12em; color:var(--star); text-decoration:none; cursor:pointer; }
   .nav-logo span { color:var(--gold); }
   .nav-links { display:flex; gap:2rem; list-style:none; }
   .nav-links a { color:var(--soft); text-decoration:none; font-size:0.75rem; letter-spacing:0.2em; text-transform:uppercase; transition:color 0.3s; cursor:pointer; }


### PR DESCRIPTION
Bumps nav logo font size from 1.2rem to 1.6rem.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QP4qNJxYN1CDX7vYxAzhJK)_