### PR TITLE
Increase nav padding for larger logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
       radial-gradient(1.2px 1.2px at 35% 80%, rgba(255,255,255,0.3) 0%, transparent 100%),
       radial-gradient(0.9px 0.9px at 80% 85%, rgba(253,230,138,0.5) 0%, transparent 100%);
   }
-  nav { position:fixed; top:0; left:0; right:0; z-index:100; padding:1.2rem 3rem; display:flex; align-items:center; justify-content:space-between; background:rgba(8,4,22,0.85); backdrop-filter:blur(12px); }
+  nav { position:fixed; top:0; left:0; right:0; z-index:100; padding:1.5rem 3rem; display:flex; align-items:center; justify-content:space-between; background:rgba(8,4,22,0.85); backdrop-filter:blur(12px); }
   .nav-logo { font-family:'Cormorant Garamond',serif; font-size:1.6rem; font-weight:300; letter-spacing:0.12em; color:var(--star); text-decoration:none; cursor:pointer; }
   .nav-logo span { color:var(--gold); }
   .nav-links { display:flex; gap:2rem; list-style:none; }


### PR DESCRIPTION
Increases nav vertical padding from 1.2rem to 1.5rem to give the 8.4rem logo room to display fully.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QP4qNJxYN1CDX7vYxAzhJK)_