### PR TITLE
Add Clarity Coaching Chrome extension

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,3 @@
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.local.set({ journal: '' });
+});

--- a/chrome-extension/icons/generate-icons.html
+++ b/chrome-extension/icons/generate-icons.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head><title>Icon Generator</title></head>
+<body>
+<p>Open browser console and run the script to generate PNG icons, or use the SVG below as a source.</p>
+
+<svg id="icon" viewBox="0 0 128 128" width="128" height="128" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#150836"/>
+      <stop offset="100%" stop-color="#080416"/>
+    </radialGradient>
+    <radialGradient id="pg" cx="42%" cy="38%" r="55%">
+      <stop offset="0%" stop-color="#c4b5fd"/>
+      <stop offset="45%" stop-color="#7c3aed"/>
+      <stop offset="100%" stop-color="#2e1065"/>
+    </radialGradient>
+    <linearGradient id="rg" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f43f5e"/>
+      <stop offset="33%" stop-color="#facc15"/>
+      <stop offset="66%" stop-color="#4ade80"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#bg)"/>
+  <circle cx="64" cy="64" r="36" fill="url(#pg)"/>
+  <ellipse cx="64" cy="72" rx="68" ry="14" fill="none" stroke="url(#rg)" stroke-width="5" opacity="0.9"/>
+  <polygon points="98,22 100,29 107,29 101,33 103,40 98,36 93,40 95,33 89,29 96,29" fill="#fde68a"/>
+</svg>
+
+<script>
+const sizes = [16, 48, 128];
+sizes.forEach(size => {
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  const img = new Image();
+  const svgData = new XMLSerializer().serializeToString(document.getElementById('icon'));
+  const blob = new Blob([svgData], {type: 'image/svg+xml'});
+  const url = URL.createObjectURL(blob);
+  img.onload = () => {
+    ctx.drawImage(img, 0, 0, size, size);
+    const link = document.createElement('a');
+    link.download = `icon${size}.png`;
+    link.href = canvas.toDataURL('image/png');
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+  img.src = url;
+});
+</script>
+</body>
+</html>

--- a/chrome-extension/icons/icon.svg
+++ b/chrome-extension/icons/icon.svg
@@ -1,0 +1,23 @@
+<svg viewBox="0 0 128 128" width="128" height="128" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#150836"/>
+      <stop offset="100%" stop-color="#080416"/>
+    </radialGradient>
+    <radialGradient id="pg" cx="42%" cy="38%" r="55%">
+      <stop offset="0%" stop-color="#c4b5fd"/>
+      <stop offset="45%" stop-color="#7c3aed"/>
+      <stop offset="100%" stop-color="#2e1065"/>
+    </radialGradient>
+    <linearGradient id="rg" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f43f5e"/>
+      <stop offset="33%" stop-color="#facc15"/>
+      <stop offset="66%" stop-color="#4ade80"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#bg)"/>
+  <circle cx="64" cy="64" r="36" fill="url(#pg)"/>
+  <ellipse cx="64" cy="72" rx="68" ry="14" fill="none" stroke="url(#rg)" stroke-width="5" opacity="0.9"/>
+  <polygon points="98,22 100,29 107,29 101,33 103,40 98,36 93,40 95,33 89,29 96,29" fill="#fde68a"/>
+</svg>

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "Cait & Scott Clarity Coaching",
+  "short_name": "Clarity Coaching",
+  "version": "1.0.0",
+  "description": "Daily clarity prompts & quick access to your coaching journey — for the 'what now?' moment.",
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Clarity Coaching"
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "permissions": ["storage"],
+  "background": {
+    "service_worker": "background.js"
+  }
+}

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Clarity Coaching</title>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;1,300;1,400&family=Jost:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="stars"></div>
+
+  <header>
+    <div class="planet-icon">
+      <svg viewBox="0 0 60 60" width="48" height="48">
+        <defs>
+          <radialGradient id="pg" cx="42%" cy="38%" r="55%">
+            <stop offset="0%" stop-color="#c4b5fd"/>
+            <stop offset="45%" stop-color="#7c3aed"/>
+            <stop offset="100%" stop-color="#2e1065"/>
+          </radialGradient>
+          <linearGradient id="rg" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stop-color="#f43f5e"/>
+            <stop offset="33%" stop-color="#facc15"/>
+            <stop offset="66%" stop-color="#4ade80"/>
+            <stop offset="100%" stop-color="#a78bfa"/>
+          </linearGradient>
+        </defs>
+        <circle cx="30" cy="30" r="19" fill="url(#pg)"/>
+        <ellipse cx="30" cy="33" rx="32" ry="8" fill="none" stroke="url(#rg)" stroke-width="2.5" opacity="0.9"/>
+        <polygon points="45,12 46,16 50,16 47,18 48,22 45,19.5 42,22 43,18 40,16 44,16" fill="#fde68a" style="transform:scale(0.6) translate(25px,2px)"/>
+      </svg>
+    </div>
+    <div class="header-text">
+      <h1>Cait &amp; Scott</h1>
+      <p class="sub">Clarity Coaching</p>
+    </div>
+  </header>
+
+  <div class="rainbow-bar"></div>
+
+  <section class="affirmation-section">
+    <p class="section-label">Today's Clarity Prompt</p>
+    <blockquote id="affirmation-text" class="affirmation"></blockquote>
+    <button id="next-prompt" class="btn-ghost" title="New prompt">&#x21bb; New prompt</button>
+  </section>
+
+  <div class="divider">
+    <span style="background:#f43f5e"></span>
+    <span style="background:#facc15"></span>
+    <span style="background:#4ade80"></span>
+    <span style="background:#38bdf8"></span>
+    <span style="background:#a78bfa"></span>
+  </div>
+
+  <section class="journal-section">
+    <p class="section-label">Quick Reflection</p>
+    <textarea id="journal" placeholder="What's on your mind today?"></textarea>
+    <div class="journal-actions">
+      <button id="save-note" class="btn-save">Save</button>
+      <span id="save-status" class="save-status"></span>
+    </div>
+  </section>
+
+  <footer>
+    <a id="book-call" href="https://claritywithcaitandscott.com" target="_blank" class="btn-primary">
+      Book Your Free Clarity Call
+    </a>
+    <p class="footer-note">You are not lost. You are becoming. ✦</p>
+  </footer>
+</body>
+<script src="popup.js"></script>
+</html>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -1,0 +1,71 @@
+const PROMPTS = [
+  "What is one small thing you can do today to move toward the life you want?",
+  "You made it through the hard part. What do you want to build now?",
+  "What would you do if you trusted yourself completely?",
+  "Name one belief that no longer serves you. What would replace it?",
+  "What does clarity feel like in your body? Can you create a little of that right now?",
+  "Who were you before the hard season — and who are you becoming?",
+  "What is one thing you've been avoiding that actually has the power to free you?",
+  "If fear weren't a factor, what would your next step be?",
+  "What do you need to hear today that nobody else has said to you?",
+  "You are not lost. You are between chapters. What is the title of your next one?",
+  "What boundary, if set today, would change everything?",
+  "What are you grieving that you haven't given yourself permission to grieve?",
+  "What would 'enough' look like — in your work, your relationships, yourself?",
+  "What does your gut know that your mind is still arguing with?",
+  "Where in your life are you performing instead of living?",
+  "What is the version of you that already made it through this doing right now?",
+  "What would you tell a dear friend who was exactly where you are?",
+  "What are you ready to release to make room for what's coming?",
+  "If this season has a lesson, what is it trying to teach you?",
+  "What one word do you want to carry with you today?",
+];
+
+function getDailyPrompt() {
+  const dayIndex = Math.floor(Date.now() / 86400000);
+  return PROMPTS[dayIndex % PROMPTS.length];
+}
+
+function getRandomPrompt(exclude) {
+  const pool = PROMPTS.filter(p => p !== exclude);
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
+const affirmationEl = document.getElementById('affirmation-text');
+const nextBtn = document.getElementById('next-prompt');
+const journalEl = document.getElementById('journal');
+const saveBtn = document.getElementById('save-note');
+const saveStatus = document.getElementById('save-status');
+
+affirmationEl.textContent = getDailyPrompt();
+
+nextBtn.addEventListener('click', () => {
+  const current = affirmationEl.textContent;
+  affirmationEl.style.opacity = '0';
+  setTimeout(() => {
+    affirmationEl.textContent = getRandomPrompt(current);
+    affirmationEl.style.transition = 'opacity 0.4s';
+    affirmationEl.style.opacity = '1';
+  }, 200);
+});
+
+chrome.storage.local.get(['journal'], (result) => {
+  if (result.journal) journalEl.value = result.journal;
+});
+
+saveBtn.addEventListener('click', () => {
+  chrome.storage.local.set({ journal: journalEl.value }, () => {
+    saveStatus.textContent = 'Saved ✦';
+    saveStatus.classList.add('visible');
+    setTimeout(() => saveStatus.classList.remove('visible'), 2000);
+  });
+});
+
+journalEl.addEventListener('keydown', (e) => {
+  if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+    e.preventDefault();
+    saveBtn.click();
+  }
+});
+
+document.getElementById('book-call').href = 'https://claritywithcaitandscott.com';

--- a/chrome-extension/styles.css
+++ b/chrome-extension/styles.css
@@ -1,0 +1,212 @@
+:root {
+  --cosmos: #080416;
+  --deep: #150836;
+  --violet: #7c3aed;
+  --lilac: #a78bfa;
+  --soft: #c4b5fd;
+  --star: #e9d5ff;
+  --gold: #fde68a;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  width: 320px;
+  background: var(--cosmos);
+  color: var(--star);
+  font-family: 'Jost', sans-serif;
+  font-weight: 300;
+  position: relative;
+  overflow-x: hidden;
+}
+
+.stars {
+  position: fixed;
+  inset: 0;
+  background-image:
+    radial-gradient(1px 1px at 12% 18%, rgba(233,213,255,0.6) 0%, transparent 100%),
+    radial-gradient(1px 1px at 82% 9%,  rgba(253,230,138,0.5) 0%, transparent 100%),
+    radial-gradient(1px 1px at 55% 25%, rgba(255,255,255,0.4) 0%, transparent 100%),
+    radial-gradient(1px 1px at 30% 70%, rgba(191,219,254,0.5) 0%, transparent 100%),
+    radial-gradient(1px 1px at 90% 55%, rgba(233,213,255,0.4) 0%, transparent 100%),
+    radial-gradient(1px 1px at 70% 85%, rgba(253,230,138,0.3) 0%, transparent 100%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.2rem 0.75rem;
+  position: relative;
+  z-index: 1;
+}
+
+.planet-icon { flex-shrink: 0; }
+
+.header-text h1 {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 1.1rem;
+  font-weight: 300;
+  color: var(--star);
+  letter-spacing: 0.05em;
+}
+
+.header-text .sub {
+  font-size: 0.65rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--lilac);
+}
+
+.rainbow-bar {
+  height: 2px;
+  background: linear-gradient(90deg, #f43f5e, #f97316, #facc15, #4ade80, #38bdf8, #a78bfa, #f43f5e);
+  position: relative;
+  z-index: 1;
+}
+
+.section-label {
+  font-size: 0.6rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--violet);
+  margin-bottom: 0.6rem;
+}
+
+/* Affirmation */
+.affirmation-section {
+  padding: 1rem 1.2rem 0.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.affirmation {
+  font-family: 'Cormorant Garamond', serif;
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--gold);
+  line-height: 1.55;
+  border-left: 2px solid var(--violet);
+  padding-left: 0.75rem;
+  margin-bottom: 0.6rem;
+  min-height: 2.5rem;
+}
+
+.btn-ghost {
+  background: transparent;
+  border: none;
+  color: var(--lilac);
+  font-family: 'Jost', sans-serif;
+  font-size: 0.65rem;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  padding: 0;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
+.btn-ghost:hover { opacity: 1; }
+
+/* Dot divider */
+.divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  margin: 0.75rem 0;
+  position: relative;
+  z-index: 1;
+}
+.divider span {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+/* Journal */
+.journal-section {
+  padding: 0 1.2rem 0.75rem;
+  position: relative;
+  z-index: 1;
+}
+
+textarea {
+  width: 100%;
+  height: 72px;
+  background: rgba(21,8,54,0.7);
+  border: 1px solid rgba(124,58,237,0.3);
+  color: var(--star);
+  padding: 0.6rem;
+  font-family: 'Jost', sans-serif;
+  font-size: 0.8rem;
+  font-weight: 300;
+  resize: none;
+  outline: none;
+  transition: border-color 0.2s;
+  line-height: 1.5;
+}
+textarea:focus { border-color: rgba(124,58,237,0.6); }
+textarea::placeholder { color: rgba(196,181,253,0.4); }
+
+.journal-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.btn-save {
+  background: transparent;
+  border: 1px solid var(--violet);
+  color: var(--lilac);
+  padding: 0.3rem 0.9rem;
+  font-family: 'Jost', sans-serif;
+  font-size: 0.65rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.btn-save:hover { background: var(--violet); color: var(--star); }
+
+.save-status {
+  font-size: 0.65rem;
+  color: #4ade80;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+.save-status.visible { opacity: 1; }
+
+/* Footer */
+footer {
+  padding: 0.75rem 1.2rem 1rem;
+  text-align: center;
+  position: relative;
+  z-index: 1;
+  border-top: 1px solid rgba(124,58,237,0.15);
+}
+
+.btn-primary {
+  display: block;
+  background: var(--violet);
+  color: var(--star);
+  padding: 0.6rem 1rem;
+  font-family: 'Jost', sans-serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  text-decoration: none;
+  text-align: center;
+  transition: background 0.2s;
+  margin-bottom: 0.6rem;
+}
+.btn-primary:hover { background: #6d28d9; }
+
+.footer-note {
+  font-size: 0.65rem;
+  color: rgba(196,181,253,0.5);
+  font-family: 'Cormorant Garamond', serif;
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary

- Adds a Chrome Manifest V3 extension at `chrome-extension/` matching the website's cosmic branding
- **Daily clarity prompt** — one rotating coaching question per day, with a shuffle button for a fresh prompt on demand
- **Quick reflection journal** — a persistent textarea saved to `chrome.storage.local` (Ctrl/Cmd+S or Save button)
- **Book Your Free Clarity Call** CTA linking to the coaching site
- Typography and color palette mirror the main site (Cormorant Garamond, Jost, violet/gold/deep cosmos)

## File structure

```
chrome-extension/
├── manifest.json        # Manifest V3, storage permission
├── popup.html           # Extension popup UI
├── popup.js             # Prompt rotation + journal save logic
├── styles.css           # Branded styles (320px popup)
├── background.js        # Service worker (initialises storage on install)
└── icons/
    ├── icon.svg         # Source SVG planet icon
    └── generate-icons.html  # Open in browser to export 16/48/128px PNGs
```

## Test plan

- [ ] Load `chrome-extension/` as an unpacked extension in Chrome (`chrome://extensions` → Load unpacked)
- [ ] Generate PNG icons by opening `icons/generate-icons.html` in a browser and downloading the three files
- [ ] Verify daily prompt displays on open
- [ ] Verify shuffle button cycles to a different prompt with fade
- [ ] Type in the journal, save, close and reopen — confirm text persists
- [ ] Verify "Book Your Free Clarity Call" opens the coaching site

https://claude.ai/code/session_011LNa49XqnQh4eRoyZUWPFN

---
_Generated by [Claude Code](https://claude.ai/code/session_011LNa49XqnQh4eRoyZUWPFN)_