### PR TITLE
Narrow nav bar — reduce link gap and add tablet breakpoint

### DIFF
--- a/index-6.html
+++ b/index-6.html
@@ -47,7 +47,7 @@
   nav { position:fixed; top:0; left:0; right:0; z-index:100; padding:1.2rem 3rem; display:flex; align-items:center; justify-content:space-between; background:#080416; backdrop-filter:blur(12px); box-shadow:0 2px 24px rgba(0,0,0,0.25); }
   .nav-logo { font-family:'Cormorant Garamond',serif; font-size:1.2rem; font-weight:300; letter-spacing:0.12em; color:#E8DFC8; text-decoration:none; cursor:pointer; }
   .nav-logo span { color:var(--gold); }
-  .nav-links { display:flex; gap:2rem; list-style:none; }
+  .nav-links { display:flex; gap:1.5rem; list-style:none; }
   .nav-links a { color:#E8DFC8; text-decoration:none; font-size:0.75rem; letter-spacing:0.2em; text-transform:uppercase; transition:color 0.3s; cursor:pointer; opacity:0.85; }
   .nav-links a:hover { color:var(--gold); }
   .nav-cta { background:linear-gradient(105deg,#7a5200 0%,#c9860a 18%,#f5d060 35%,#e8a800 50%,#f5d060 65%,#c9860a 82%,#7a5200 100%); background-size:200% auto; color:#1a0a00; padding:0.5rem 1.4rem; font-family:'Lora',serif; font-size:0.75rem; letter-spacing:0.15em; text-transform:uppercase; cursor:pointer; border:none; font-weight:700; animation:shimmer 5s linear infinite; box-shadow:0 0 12px rgba(229,180,30,0.45); text-decoration:none; }
@@ -163,6 +163,7 @@
   .success-msg { display:none; background:rgba(74,222,128,0.1); border:1px solid rgba(74,222,128,0.3); border-left:3px solid var(--green); padding:2rem; text-align:center; margin-top:1rem; }
   .success-msg h3 { font-family:'Cormorant Garamond',serif; font-size:1.5rem; color:var(--green); margin-bottom:0.5rem; }
   .success-msg p { color:#86efac; font-size:0.9rem; }
+  @media(max-width:1024px) { nav { padding:1rem 2rem; } .nav-links { gap:1.2rem; } }
   @media(max-width:768px) { nav { padding:1rem 1.5rem; } .nav-links { display:none; } }
   @keyframes fadeUp { from { opacity:0; transform:translateY(20px); } to { opacity:1; transform:translateY(0); } }
   .fade-up { animation:fadeUp 0.8s ease forwards; }

--- a/index-6.html
+++ b/index-6.html
@@ -50,14 +50,14 @@
   .nav-links { display:flex; gap:2rem; list-style:none; }
   .nav-links a { color:#E8DFC8; text-decoration:none; font-size:0.75rem; letter-spacing:0.2em; text-transform:uppercase; transition:color 0.3s; cursor:pointer; opacity:0.85; }
   .nav-links a:hover { color:var(--gold); }
-  .nav-cta { background:linear-gradient(105deg,#7a5200 0%,#c9860a 18%,#f5d060 35%,#e8a800 50%,#f5d060 65%,#c9860a 82%,#7a5200 100%); background-size:200% auto; color:#1a0a00; padding:0.5rem 1.4rem; font-family:'Lora',serif; font-size:0.75rem; letter-spacing:0.15em; text-transform:uppercase; cursor:pointer; border:none; font-weight:700; animation:shimmer 2.8s linear infinite; box-shadow:0 0 12px rgba(229,180,30,0.45); text-decoration:none; }
+  .nav-cta { background:linear-gradient(105deg,#7a5200 0%,#c9860a 18%,#f5d060 35%,#e8a800 50%,#f5d060 65%,#c9860a 82%,#7a5200 100%); background-size:200% auto; color:#1a0a00; padding:0.5rem 1.4rem; font-family:'Lora',serif; font-size:0.75rem; letter-spacing:0.15em; text-transform:uppercase; cursor:pointer; border:none; font-weight:700; animation:shimmer 5s linear infinite; box-shadow:0 0 12px rgba(229,180,30,0.45); text-decoration:none; }
   .nav-cta:hover { opacity:0.9; }
   @keyframes shimmer { 0% { background-position:200% center; } 100% { background-position:-200% center; } }
   .page { display:none; min-height:100vh; padding-top:5rem; position:relative; z-index:1; }
   .page.active { display:block; }
   .rainbow-bar { height:3px; background:linear-gradient(90deg,#c0306a 0%,#d4603a 14%,#c9a040 28%,#3a9a50 42%,#2a70c0 56%,#3a30b0 72%,#6a20a0 86%,#9a20c0 100%); width:100%; }
   .section-label { font-size:0.65rem; letter-spacing:0.35em; text-transform:uppercase; color:var(--violet); margin-bottom:1rem; }
-  .btn-primary { display:inline-block; background:linear-gradient(105deg,#7a5200 0%,#c9860a 18%,#f5d060 35%,#e8a800 50%,#f5d060 65%,#c9860a 82%,#7a5200 100%); background-size:200% auto; color:#1a0a00; padding:0.9rem 2.5rem; font-family:'Lora',serif; font-size:0.78rem; letter-spacing:0.2em; text-transform:uppercase; text-decoration:none; border:none; cursor:pointer; font-weight:700; animation:shimmer 2.8s linear infinite; box-shadow:0 0 14px rgba(229,180,30,0.4); }
+  .btn-primary { display:inline-block; background:linear-gradient(105deg,#7a5200 0%,#c9860a 18%,#f5d060 35%,#e8a800 50%,#f5d060 65%,#c9860a 82%,#7a5200 100%); background-size:200% auto; color:#1a0a00; padding:0.9rem 2.5rem; font-family:'Lora',serif; font-size:0.78rem; letter-spacing:0.2em; text-transform:uppercase; text-decoration:none; border:none; cursor:pointer; font-weight:700; animation:shimmer 5s linear infinite; box-shadow:0 0 14px rgba(229,180,30,0.4); }
   .btn-primary:hover { opacity:0.9; }
   .btn-outline { display:inline-block; background:transparent; color:var(--lilac); padding:0.9rem 2.5rem; font-family:'Lora',serif; font-size:0.78rem; letter-spacing:0.2em; text-transform:uppercase; text-decoration:none; border:1px solid var(--violet); transition:all 0.3s; cursor:pointer; }
   .btn-outline:hover { background:var(--violet); color:var(--star); }

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
   nav { position:fixed; top:0; left:0; right:0; z-index:100; padding:1.5rem 3rem; display:flex; align-items:center; justify-content:space-between; background:#080416; backdrop-filter:blur(12px); box-shadow:0 2px 24px rgba(0,0,0,0.25); }
   .nav-logo { font-family:'Cormorant Garamond',serif; font-size:1.6rem; font-weight:300; letter-spacing:0.12em; color:#E8DFC8; text-decoration:none; cursor:pointer; }
   .nav-logo span { color:var(--gold); }
-  .nav-links { display:flex; gap:4rem; list-style:none; }
+  .nav-links { display:flex; gap:2rem; list-style:none; }
   .nav-links a { color:#E8DFC8; text-decoration:none; font-size:0.75rem; letter-spacing:0.2em; text-transform:uppercase; transition:color 0.3s; cursor:pointer; opacity:0.85; }
   .nav-links a:hover { color:var(--gold); }
   .nav-cta { background:linear-gradient(105deg,#7a5200 0%,#c9860a 18%,#f5d060 35%,#e8a800 50%,#f5d060 65%,#c9860a 82%,#7a5200 100%); background-size:200% auto; color:#1a0a00; padding:0.5rem 1.4rem; font-family:'Lora',serif; font-size:0.75rem; letter-spacing:0.15em; text-transform:uppercase; cursor:pointer; border:none; font-weight:700; animation:shimmer 5s linear infinite; box-shadow:0 0 12px rgba(229,180,30,0.45); }
@@ -174,6 +174,7 @@
   .mobile-menu a { color:var(--star); text-decoration:none; font-family:'Cormorant Garamond',serif; font-size:2rem; font-weight:300; letter-spacing:0.15em; transition:color 0.3s; }
   .mobile-menu a:hover { color:var(--gold); }
   .mobile-menu .mobile-cta { margin-top:1rem; background:var(--violet); color:var(--star); padding:0.9rem 2.5rem; font-family:'Lora',serif; font-size:0.8rem; letter-spacing:0.2em; text-transform:uppercase; border:none; cursor:pointer; }
+  @media(max-width:1024px) { nav { padding:1rem 2rem; } .nav-links { gap:1.5rem; } }
   @media(max-width:768px) { nav { padding:1rem 1.5rem; } .nav-links { display:none; } .hamburger { display:flex; } }
   @keyframes fadeUp { from { opacity:0; transform:translateY(20px); } to { opacity:1; transform:translateY(0); } }
   .fade-up { animation:fadeUp 0.8s ease forwards; }

--- a/index.html
+++ b/index.html
@@ -51,14 +51,14 @@
   .nav-links { display:flex; gap:4rem; list-style:none; }
   .nav-links a { color:#E8DFC8; text-decoration:none; font-size:0.75rem; letter-spacing:0.2em; text-transform:uppercase; transition:color 0.3s; cursor:pointer; opacity:0.85; }
   .nav-links a:hover { color:var(--gold); }
-  .nav-cta { background:linear-gradient(105deg,#7a5200 0%,#c9860a 18%,#f5d060 35%,#e8a800 50%,#f5d060 65%,#c9860a 82%,#7a5200 100%); background-size:200% auto; color:#1a0a00; padding:0.5rem 1.4rem; font-family:'Lora',serif; font-size:0.75rem; letter-spacing:0.15em; text-transform:uppercase; cursor:pointer; border:none; font-weight:700; animation:shimmer 2.8s linear infinite; box-shadow:0 0 12px rgba(229,180,30,0.45); }
+  .nav-cta { background:linear-gradient(105deg,#7a5200 0%,#c9860a 18%,#f5d060 35%,#e8a800 50%,#f5d060 65%,#c9860a 82%,#7a5200 100%); background-size:200% auto; color:#1a0a00; padding:0.5rem 1.4rem; font-family:'Lora',serif; font-size:0.75rem; letter-spacing:0.15em; text-transform:uppercase; cursor:pointer; border:none; font-weight:700; animation:shimmer 5s linear infinite; box-shadow:0 0 12px rgba(229,180,30,0.45); }
   .nav-cta:hover { opacity:0.9; }
   @keyframes shimmer { 0% { background-position:200% center; } 100% { background-position:-200% center; } }
   .page { display:none; min-height:100vh; padding-top:5rem; position:relative; z-index:1; }
   .page.active { display:block; }
   .rainbow-bar { height:3px; background:linear-gradient(90deg,#c0306a 0%,#d4603a 14%,#c9a040 28%,#3a9a50 42%,#2a70c0 56%,#3a30b0 72%,#6a20a0 86%,#9a20c0 100%); width:100%; }
   .section-label { font-size:0.65rem; letter-spacing:0.35em; text-transform:uppercase; color:var(--violet); margin-bottom:1rem; }
-  .btn-primary { display:inline-block; background:linear-gradient(105deg,#7a5200 0%,#c9860a 18%,#f5d060 35%,#e8a800 50%,#f5d060 65%,#c9860a 82%,#7a5200 100%); background-size:200% auto; color:#1a0a00; padding:0.9rem 2.5rem; font-family:'Lora',serif; font-size:0.78rem; letter-spacing:0.2em; text-transform:uppercase; border:none; cursor:pointer; font-weight:700; animation:shimmer 2.8s linear infinite; box-shadow:0 0 14px rgba(229,180,30,0.4); }
+  .btn-primary { display:inline-block; background:linear-gradient(105deg,#7a5200 0%,#c9860a 18%,#f5d060 35%,#e8a800 50%,#f5d060 65%,#c9860a 82%,#7a5200 100%); background-size:200% auto; color:#1a0a00; padding:0.9rem 2.5rem; font-family:'Lora',serif; font-size:0.78rem; letter-spacing:0.2em; text-transform:uppercase; border:none; cursor:pointer; font-weight:700; animation:shimmer 5s linear infinite; box-shadow:0 0 14px rgba(229,180,30,0.4); }
   .btn-primary:hover { opacity:0.9; }
   .btn-outline { display:inline-block; background:transparent; color:var(--lilac); padding:0.9rem 2.5rem; font-family:'Lora',serif; font-size:0.78rem; letter-spacing:0.2em; text-transform:uppercase; border:1px solid var(--lilac); cursor:pointer; transition:all 0.3s; text-decoration:none; }
   .btn-outline:hover { background:var(--violet); color:var(--star); }


### PR DESCRIPTION
Reduces nav link gap from 4rem to 2rem and adds a 1024px breakpoint to prevent nav items from overflowing on tablet-sized screens.

https://claude.ai/code/session_01Nidii5zSPB9ojKjsYcSxgf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nidii5zSPB9ojKjsYcSxgf)_