### PR TITLE
Fix invisible text on dark elements and lavender footer text

### DIFF
--- a/index-6.html
+++ b/index-6.html
@@ -14,7 +14,7 @@
     --violet: #3D1A6E;
     --lilac: #5A2D9A;
     --soft: #2C2C2C;
-    --star: #2C2C2C;
+    --star: #E8DFC8;
     --gold: #c9a96e;
     --gold-bright: #D4AF6A;
     --rose: #c0306a;
@@ -152,10 +152,10 @@
   .footer-cta { margin:1.5rem 0; }
   .footer-tag { font-size:0.7rem; letter-spacing:0.3em; color:var(--violet); margin-bottom:1rem; }
   .footer-legal-links { display:flex; justify-content:center; gap:2rem; margin-top:1rem; }
-  .footer-legal-links a { font-size:0.68rem; color:rgba(196,181,253,0.4); text-decoration:none; letter-spacing:0.1em; transition:color 0.3s; cursor:pointer; }
+  .footer-legal-links a { font-size:0.68rem; color:rgba(232,223,200,0.5); text-decoration:none; letter-spacing:0.1em; transition:color 0.3s; cursor:pointer; }
   .footer-legal-links a:hover { color:var(--lilac); }
-  .footer-copy { font-size:0.72rem; color:rgba(196,181,253,0.4); margin-top:1rem; }
-  .footer-disclaimer { font-size:0.68rem; color:rgba(196,181,253,0.35); max-width:700px; margin:1.2rem auto 0; line-height:1.7; font-style:italic; border-top:1px solid rgba(124,58,237,0.1); padding-top:1.2rem; }
+  .footer-copy { font-size:0.72rem; color:rgba(232,223,200,0.5); margin-top:1rem; }
+  .footer-disclaimer { font-size:0.68rem; color:rgba(232,223,200,0.4); max-width:700px; margin:1.2rem auto 0; line-height:1.7; font-style:italic; border-top:1px solid rgba(124,58,237,0.1); padding-top:1.2rem; }
   .waitlist-banner { background:rgba(74,222,128,0.08); border:1px solid rgba(74,222,128,0.2); padding:2rem; text-align:center; margin-top:2rem; }
   .waitlist-banner h3 { font-family:'Cormorant Garamond',serif; font-size:1.5rem; color:var(--green); margin-bottom:0.5rem; }
   .waitlist-banner p { color:#86efac; font-size:0.9rem; margin-bottom:1.2rem; }

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     --violet: #3D1A6E;
     --lilac: #5A2D9A;
     --soft: #2C2C2C;
-    --star: #2C2C2C;
+    --star: #E8DFC8;
     --gold: #c9a96e;
     --gold-bright: #D4AF6A;
     --rose: #c0306a;
@@ -153,10 +153,10 @@
   .footer-cta { margin:1.5rem 0; }
   .footer-tag { font-size:0.7rem; letter-spacing:0.3em; color:var(--violet); margin-bottom:1rem; }
   .footer-legal-links { display:flex; justify-content:center; gap:2rem; margin-top:1rem; }
-  .footer-legal-links a { font-size:0.68rem; color:rgba(196,181,253,0.4); text-decoration:none; letter-spacing:0.1em; transition:color 0.3s; cursor:pointer; }
+  .footer-legal-links a { font-size:0.68rem; color:rgba(232,223,200,0.5); text-decoration:none; letter-spacing:0.1em; transition:color 0.3s; cursor:pointer; }
   .footer-legal-links a:hover { color:var(--lilac); }
-  .footer-copy { font-size:0.72rem; color:rgba(196,181,253,0.4); margin-top:1rem; }
-  .footer-disclaimer { font-size:0.68rem; color:rgba(196,181,253,0.35); max-width:700px; margin:1.2rem auto 0; line-height:1.7; font-style:italic; border-top:1px solid rgba(124,58,237,0.1); padding-top:1rem; }
+  .footer-copy { font-size:0.72rem; color:rgba(232,223,200,0.5); margin-top:1rem; }
+  .footer-disclaimer { font-size:0.68rem; color:rgba(232,223,200,0.4); max-width:700px; margin:1.2rem auto 0; line-height:1.7; font-style:italic; border-top:1px solid rgba(124,58,237,0.1); padding-top:1rem; }
   .waitlist-banner { background:rgba(74,222,128,0.08); border:1px solid rgba(74,222,128,0.2); padding:2rem; text-align:center; margin-top:2rem; }
   .waitlist-banner h3 { font-family:'Cormorant Garamond',serif; font-size:1.5rem; color:var(--green); margin-bottom:0.5rem; }
   .waitlist-banner p { color:#86efac; font-size:0.9rem; margin-bottom:1.2rem; }
@@ -294,7 +294,7 @@
 <h2 style="font-family:'Cormorant Garamond',serif;font-size:clamp(1.8rem,4vw,3rem);font-weight:300;color:var(--star);margin-bottom:1rem;line-height:1.3;">I'm ready to help you take your next step forward.</h2>
 <p style="font-family:'Cormorant Garamond',serif;font-size:clamp(1.4rem,3vw,2.2rem);font-style:italic;color:var(--gold);margin-bottom:2.5rem;">Are you?</p>
 <a class="btn-primary" onclick="showPage('apply')" style="font-size:0.85rem;letter-spacing:0.2em;padding:1rem 3rem;">Start Here</a>
-<p style="margin-top:1.2rem;font-size:0.72rem;letter-spacing:0.15em;color:rgba(196,181,253,0.5);text-transform:uppercase;">It's free. Always.</p>
+<p style="margin-top:1.2rem;font-size:0.72rem;letter-spacing:0.15em;color:rgba(232,223,200,0.55);text-transform:uppercase;">It's free. Always.</p>
 </div>
 </section>
 <footer>


### PR DESCRIPTION
- Restores `--star` to `#E8DFC8` (light cream) so all dark-background elements (mobile menu links, hamburger bars, cards, form inputs) have readable light text
- Replaces lavender `rgba(196,181,253,...)` footer text with warm cream `rgba(232,223,200,...)`

https://claude.ai/code/session_01Nidii5zSPB9ojKjsYcSxgf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nidii5zSPB9ojKjsYcSxgf)_