### PR TITLE
Gold text on all dark purple backgrounds

### DIFF
--- a/index-6.html
+++ b/index-6.html
@@ -83,8 +83,8 @@
   @media(max-width:680px) { .pillars-top { grid-template-columns:1fr; } .pillars-bottom { grid-template-columns:1fr; max-width:100%; } }
   .pillar-card { background:rgba(21,8,54,0.92); border:1px solid rgba(124,58,237,0.2); padding:2rem 1.5rem; text-align:center; transition:border-color 0.3s; }
   .pillar-card:hover { border-color:rgba(124,58,237,0.5); }
-  .pillar-card h3 { font-family:'Cormorant Garamond',serif; font-size:1.2rem; font-weight:400; color:var(--star); margin-bottom:0.5rem; margin-top:0.8rem; }
-  .pillar-card p { font-size:0.82rem; color:var(--lilac); line-height:1.6; }
+  .pillar-card h3 { font-family:'Cormorant Garamond',serif; font-size:1.2rem; font-weight:400; color:var(--gold-bright); margin-bottom:0.5rem; margin-top:0.8rem; }
+  .pillar-card p { font-size:0.82rem; color:var(--gold); line-height:1.6; }
   .pillar-accent { font-size:0.65rem; letter-spacing:0.2em; margin-top:0.8rem; display:block; }
   /* SERVICES */
   .service-card { background:rgba(21,8,54,0.92); border:1px solid rgba(124,58,237,0.2); padding:3rem; margin-bottom:2rem; transition:border-color 0.3s; }
@@ -93,18 +93,18 @@
   .service-card.s2 { border-left:4px solid var(--violet); }
   .service-card.s3 { border-left:4px solid var(--blue); }
   .service-label { font-size:0.65rem; letter-spacing:0.3em; text-transform:uppercase; margin-bottom:0.5rem; }
-  .service-card h2 { font-family:'Cormorant Garamond',serif; font-size:1.8rem; font-weight:300; color:var(--star); margin-bottom:0.5rem; }
+  .service-card h2 { font-family:'Cormorant Garamond',serif; font-size:1.8rem; font-weight:300; color:var(--gold-bright); margin-bottom:0.5rem; }
   .service-price { font-size:1.1rem; color:var(--gold); margin-bottom:1rem; font-family:'Cormorant Garamond',serif; font-style:italic; }
-  .service-card p { color:var(--soft); line-height:1.9; font-size:0.95rem; margin-bottom:1.5rem; }
+  .service-card p { color:var(--gold); line-height:1.9; font-size:0.95rem; margin-bottom:1.5rem; }
   /* ABOUT */
   .about-grid { display:grid; grid-template-columns:1fr 1fr; gap:2rem; margin:2rem 0; }
   @media(max-width:620px) { .about-grid { grid-template-columns:1fr; } }
   .about-card { background:rgba(8,4,22,0.92); border:1px solid rgba(124,58,237,0.2); padding:2rem; }
   .about-card.scott { border-top:3px solid var(--blue); }
   .about-card.cait { border-top:3px solid var(--lilac); }
-  .about-card h3 { font-family:'Cormorant Garamond',serif; font-size:1.4rem; color:var(--star); margin-bottom:1rem; }
-  .about-card p { color:var(--soft); font-size:0.9rem; line-height:1.9; }
-  .bio-block { background:rgba(21,8,54,0.6); border:1px solid rgba(124,58,237,0.2); border-left:3px solid var(--violet); padding:2.5rem; line-height:1.9; color:var(--soft); font-size:1rem; margin-bottom:2rem; }
+  .about-card h3 { font-family:'Cormorant Garamond',serif; font-size:1.4rem; color:var(--gold-bright); margin-bottom:1rem; }
+  .about-card p { color:var(--gold); font-size:0.9rem; line-height:1.9; }
+  .bio-block { background:rgba(21,8,54,0.6); border:1px solid rgba(124,58,237,0.2); border-left:3px solid var(--violet); padding:2.5rem; line-height:1.9; color:var(--gold); font-size:1rem; margin-bottom:2rem; }
   .bio-block em { color:var(--gold); font-style:normal; }
   .mv-grid { display:grid; grid-template-columns:1fr 1fr; gap:2rem; margin:2rem 0; }
   @media(max-width:620px) { .mv-grid { grid-template-columns:1fr; } }
@@ -127,7 +127,7 @@
   .form-group textarea { height:120px; resize:vertical; }
   .form-group select option { background:#150836; }
   .scale-row { display:flex; gap:0.5rem; flex-wrap:wrap; }
-  .scale-btn { width:40px; height:40px; background:rgba(21,8,54,0.7); border:1px solid rgba(124,58,237,0.3); color:var(--lilac); font-family:'Lora',serif; font-size:0.85rem; cursor:pointer; transition:all 0.2s; }
+  .scale-btn { width:40px; height:40px; background:rgba(21,8,54,0.7); border:1px solid rgba(124,58,237,0.3); color:var(--gold); font-family:'Lora',serif; font-size:0.85rem; cursor:pointer; transition:all 0.2s; }
   .scale-btn:hover, .scale-btn.active { background:var(--violet); color:var(--star); border-color:var(--violet); }
   /* CONTACT */
   .contact-grid { display:grid; grid-template-columns:1fr 1fr; gap:3rem; max-width:900px; margin:2rem auto; padding:0 2rem 4rem; }

--- a/index.html
+++ b/index.html
@@ -84,8 +84,8 @@
   @media(max-width:680px) { .pillars-top { grid-template-columns:1fr; } .pillars-bottom { grid-template-columns:1fr; max-width:100%; } }
   .pillar-card { background:rgba(21,8,54,0.92); border:1px solid rgba(124,58,237,0.2); padding:2rem 1.5rem; text-align:center; transition:border-color 0.3s; }
   .pillar-card:hover { border-color:rgba(124,58,237,0.5); }
-  .pillar-card h3 { font-family:'Cormorant Garamond',serif; font-size:1.2rem; font-weight:400; color:var(--star); margin-bottom:0.5rem; margin-top:0.8rem; }
-  .pillar-card p { font-size:0.82rem; color:var(--lilac); line-height:1.6; }
+  .pillar-card h3 { font-family:'Cormorant Garamond',serif; font-size:1.2rem; font-weight:400; color:var(--gold-bright); margin-bottom:0.5rem; margin-top:0.8rem; }
+  .pillar-card p { font-size:0.82rem; color:var(--gold); line-height:1.6; }
   .pillar-accent { font-size:0.65rem; letter-spacing:0.2em; margin-top:0.8rem; display:block; }
   /* SERVICES */
   .service-card { background:rgba(21,8,54,0.92); border:1px solid rgba(124,58,237,0.2); padding:3rem; margin-bottom:2rem; transition:border-color 0.3s; }
@@ -94,18 +94,18 @@
   .service-card.s2 { border-left:4px solid var(--violet); }
   .service-card.s3 { border-left:4px solid var(--blue); }
   .service-label { font-size:0.65rem; letter-spacing:0.3em; text-transform:uppercase; margin-bottom:0.5rem; }
-  .service-card h2 { font-family:'Cormorant Garamond',serif; font-size:1.8rem; font-weight:300; color:var(--star); margin-bottom:0.5rem; }
+  .service-card h2 { font-family:'Cormorant Garamond',serif; font-size:1.8rem; font-weight:300; color:var(--gold-bright); margin-bottom:0.5rem; }
   .service-price { font-size:1.1rem; color:var(--gold); margin-bottom:1rem; font-family:'Cormorant Garamond',serif; font-style:italic; }
-  .service-card p { color:var(--soft); line-height:1.9; font-size:0.95rem; margin-bottom:1.5rem; }
+  .service-card p { color:var(--gold); line-height:1.9; font-size:0.95rem; margin-bottom:1.5rem; }
   /* ABOUT */
   .about-grid { display:grid; grid-template-columns:1fr 1fr; gap:2rem; margin:2rem 0; }
   @media(max-width:620px) { .about-grid { grid-template-columns:1fr; } }
   .about-card { background:rgba(8,4,22,0.92); border:1px solid rgba(124,58,237,0.2); padding:2rem; }
   .about-card.scott { border-top:3px solid var(--blue); }
   .about-card.cait { border-top:3px solid var(--lilac); }
-  .about-card h3 { font-family:'Cormorant Garamond',serif; font-size:1.4rem; color:var(--star); margin-bottom:1rem; }
-  .about-card p { color:var(--soft); font-size:0.9rem; line-height:1.9; }
-  .bio-block { background:rgba(21,8,54,0.6); border:1px solid rgba(124,58,237,0.2); border-left:3px solid var(--violet); padding:2.5rem; line-height:1.9; color:var(--soft); font-size:1rem; margin-bottom:2rem; }
+  .about-card h3 { font-family:'Cormorant Garamond',serif; font-size:1.4rem; color:var(--gold-bright); margin-bottom:1rem; }
+  .about-card p { color:var(--gold); font-size:0.9rem; line-height:1.9; }
+  .bio-block { background:rgba(21,8,54,0.6); border:1px solid rgba(124,58,237,0.2); border-left:3px solid var(--violet); padding:2.5rem; line-height:1.9; color:var(--gold); font-size:1rem; margin-bottom:2rem; }
   .bio-block em { color:var(--gold); font-style:normal; }
   .mv-grid { display:grid; grid-template-columns:1fr 1fr; gap:2rem; margin:2rem 0; }
   @media(max-width:620px) { .mv-grid { grid-template-columns:1fr; } }
@@ -128,7 +128,7 @@
   .form-group textarea { height:120px; resize:vertical; }
   .form-group select option { background:#150836; }
   .scale-row { display:flex; gap:0.5rem; flex-wrap:wrap; }
-  .scale-btn { width:40px; height:40px; background:rgba(21,8,54,0.7); border:1px solid rgba(124,58,237,0.3); color:var(--lilac); font-family:'Lora',serif; font-size:0.85rem; cursor:pointer; transition:all 0.3s; }
+  .scale-btn { width:40px; height:40px; background:rgba(21,8,54,0.7); border:1px solid rgba(124,58,237,0.3); color:var(--gold); font-family:'Lora',serif; font-size:0.85rem; cursor:pointer; transition:all 0.3s; }
   .scale-btn:hover, .scale-btn.active { background:var(--violet); color:var(--star); border-color:var(--violet); }
   /* CONTACT */
   .contact-grid { display:grid; grid-template-columns:1fr 1fr; gap:3rem; max-width:900px; margin:2rem auto; padding:0 2rem 4rem; }
@@ -171,7 +171,7 @@
   .hamburger.open span:nth-child(3) { transform:translateY(-7px) rotate(-45deg); }
   .mobile-menu { display:none; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(8,4,22,0.97); z-index:150; flex-direction:column; align-items:center; justify-content:center; gap:2.5rem; }
   .mobile-menu.open { display:flex; }
-  .mobile-menu a { color:var(--star); text-decoration:none; font-family:'Cormorant Garamond',serif; font-size:2rem; font-weight:300; letter-spacing:0.15em; transition:color 0.3s; }
+  .mobile-menu a { color:var(--gold-bright); text-decoration:none; font-family:'Cormorant Garamond',serif; font-size:2rem; font-weight:300; letter-spacing:0.15em; transition:color 0.3s; }
   .mobile-menu a:hover { color:var(--gold); }
   .mobile-menu .mobile-cta { margin-top:1rem; background:var(--violet); color:var(--star); padding:0.9rem 2.5rem; font-family:'Lora',serif; font-size:0.8rem; letter-spacing:0.2em; text-transform:uppercase; border:none; cursor:pointer; }
   @media(max-width:1024px) { nav { padding:1rem 2rem; } .nav-links { gap:1.5rem; } }


### PR DESCRIPTION
Sets all text on dark purple/navy backgrounds to gold. Headings use `--gold-bright` (#D4AF6A), body/paragraph text uses `--gold` (#c9a96e). Covers: pillar cards, service cards, about cards, bio blocks, scale buttons, mobile menu links.

https://claude.ai/code/session_01Nidii5zSPB9ojKjsYcSxgf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nidii5zSPB9ojKjsYcSxgf)_