### PR TITLE
Add .claude/settings.json with permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run lint *)",
+      "Bash(npm run typecheck *)",
+      "Bash(npm test *)",
+      "Bash(npx tsc --noEmit *)",
+      "Bash(curl -s *)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with read-only permission allowlist to reduce prompts for lint, typecheck, test, and curl commands

https://claude.ai/code/session_012vVbA5ZKR9kQkpGDfso1Xt

---
_Generated by [Claude Code](https://claude.ai/code/session_012vVbA5ZKR9kQkpGDfso1Xt)_