### PR TITLE
Site polish: service packages, contact, FAQ, About/Services spacing, home cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,26 +413,26 @@ Scott tracks what keeps repeating in your story. Cait listens for what's underne
 </div>
 <div class="section" style="padding-top:0">
 <div class="service-card s1">
-<p class="service-label" style="color:var(--gold)">90-Minute Session</p>
+<p class="service-label" style="color:var(--gold)">Focused Session</p>
 <h2>Pattern Break Intensive</h2>
 <div class="service-price">$197</div>
-<p>A focused 90-minute session to identify and interrupt a key pattern keeping you stuck. We uncover the loop, expose the belief driving it, and give you a clear, actionable next step.</p>
-<p style="font-size:0.9rem;color:var(--gold);font-style:italic;">In a single session, you get two trained perspectives on the same pattern — which means you leave with something most people don't find for years.</p>
+<p>A focused session to identify and interrupt a key pattern keeping you stuck. We uncover the loop, expose the belief driving it, and give you a clear, actionable next step.</p>
+<p style="font-size:0.9rem;color:var(--gold);font-style:italic;">You get two trained perspectives on the same pattern — which means you leave with something most people don't find for years.</p>
 <a class="btn-primary" href="https://caitlyn16dl.setmore.com/" target="_blank" rel="noopener noreferrer" style="font-size:0.72rem;padding:0.7rem 1.8rem">Start Here</a>
 </div>
 <div class="service-card s2">
-<p class="service-label" style="color:var(--gold)">6–8 Week Experience</p>
+<p class="service-label" style="color:var(--gold)">Coaching Experience</p>
 <h2>Loop Breaker Method</h2>
 <div class="service-price">$797</div>
-<p>A 6–8 week coaching experience to help you stop repeating the same patterns in your life, relationships, and decisions. We identify hidden loops, shift the core beliefs driving them, and guide you through sustainable change.</p>
-<p style="font-size:0.9rem;color:var(--gold);font-style:italic;">Over 6-8 weeks, Scott is tracking what keeps repeating in your story while Cait is listening for what's underneath it — and between the two of us, nothing slips through.</p>
+<p>A coaching experience to help you stop repeating the same patterns in your life, relationships, and decisions. We identify hidden loops, shift the core beliefs driving them, and guide you through sustainable change.</p>
+<p style="font-size:0.9rem;color:var(--gold);font-style:italic;">Throughout our work together, Scott is tracking what keeps repeating in your story while Cait is listening for what's underneath it — and between the two of us, nothing slips through.</p>
 <a class="btn-outline" href="https://caitlyn16dl.setmore.com/" target="_blank" rel="noopener noreferrer" style="font-size:0.72rem;padding:0.7rem 1.8rem">Start Here</a>
 </div>
 <div class="service-card s3">
-<p class="service-label" style="color:var(--blue)">10–12 Week Experience</p>
+<p class="service-label" style="color:var(--blue)">Deep Coaching Experience</p>
 <h2>Identity Rewire Experience</h2>
 <div class="service-price">$1,997</div>
-<p>A high-touch 10–12 week experience designed to help you break deeper patterns and permanently shift the beliefs driving them. We rewire core beliefs and reinforce new behaviors so change holds.</p>
+<p>A high-touch experience designed to help you break deeper patterns and permanently shift the beliefs driving them. We rewire core beliefs and reinforce new behaviors so change holds.</p>
 <p style="font-size:0.9rem;color:var(--gold);font-style:italic;">This is the deepest level of work we do — and having both of us in it means the belief gets found faster, challenged from two angles, and replaced with something that actually holds.</p>
 <a class="btn-outline" href="https://caitlyn16dl.setmore.com/" target="_blank" rel="noopener noreferrer" style="font-size:0.72rem;padding:0.7rem 1.8rem;border-color:var(--violet);color:var(--violet)">Start Here</a>
 </div>
@@ -466,7 +466,7 @@ Scott tracks what keeps repeating in your story. Cait listens for what's underne
 <div class="faq-item"><div class="faq-q">How do I get started?</div><div class="faq-a">Fill out the form on our Apply page. We'll be in touch within 48 hours to schedule your free discovery call.</div></div>
 <div class="faq-item"><div class="faq-q">Why are spots limited?</div><div class="faq-a">Because this work only works when there's enough space to do it well. We keep client spots limited so every person gets the full attention they deserve.</div></div>
 <div class="faq-item"><div class="faq-q">I've tried coaching before and it didn't work. Why would this be different?</div><div class="faq-a">Because we don't start with generic advice. You get both of us from day one — two trained perspectives on your specific pattern, not one-size-fits-all coaching.</div></div>
-<div class="faq-item"><div class="faq-q">Do you offer packages?</div><div class="faq-a">Yes — our Loop Breaker Method (6–8 weeks) and Identity Rewire Experience (10–12 weeks) are our core packages. Both include both coaches.</div></div>
+<div class="faq-item"><div class="faq-q">Do you offer packages?</div><div class="faq-a">Yes — our Loop Breaker Method and Identity Rewire Experience are our core packages. Both include both coaches.</div></div>
 <div class="faq-item"><div class="faq-q">What is your refund policy?</div><div class="faq-a">We offer a full refund if you cancel before your first session. If you need to cancel within 48 hours of a session, we'll reschedule instead of charging.</div></div>
 <div class="faq-item"><div class="faq-q">What are your business hours?</div><div class="faq-a">We work with clients across time zones. Availability varies — we'll share current open times when you apply.</div></div>
 <div style="text-align:center;margin-top:3rem">

--- a/index.html
+++ b/index.html
@@ -107,9 +107,11 @@
   .mv-card.vision h3 { color:var(--blue); }
   .mv-card p { font-family:'Cormorant Garamond',serif; font-size:1.1rem; font-style:italic; color:#2C2C2C; line-height:1.8; }
   /* FAQ */
-  .faq-item { border-bottom:1px solid rgba(124,58,237,0.15); padding:1.5rem 0; }
-  .faq-q { font-family:'Cormorant Garamond',serif; font-size:1.15rem; color:var(--soft); margin-bottom:0.8rem; }
-  .faq-a { color:var(--soft); font-size:0.9rem; line-height:1.9; }
+  #page-faq .section { counter-reset: faq-counter; }
+  .faq-item { counter-increment: faq-counter; border-bottom:1px solid rgba(61,26,110,0.15); padding:2rem 0; }
+  .faq-q { font-family:'Cormorant Garamond',serif; font-size:1.2rem; color:var(--violet); margin-bottom:0.8rem; }
+  .faq-q::before { content: counter(faq-counter) ".  "; color:var(--gold); }
+  .faq-a { color:#555555; font-size:0.92rem; line-height:1.9; padding-left:1.4rem; border-left:2px solid rgba(201,169,110,0.4); }
   /* FORM */
   .form-group { margin-bottom:1.8rem; }
   .form-group label { display:block; font-size:0.72rem; letter-spacing:0.2em; text-transform:uppercase; color:var(--violet); margin-bottom:0.6rem; }

--- a/index.html
+++ b/index.html
@@ -594,7 +594,7 @@ Scott tracks what keeps repeating in your story. Cait listens for what's underne
 <span style="background:#f43f5e"></span><span style="background:#facc15"></span><span style="background:#4ade80"></span><span style="background:#38bdf8"></span><span style="background:#a78bfa"></span>
 </div>
 </div>
-<div class="contact-grid">
+<div class="contact-grid" style="background:#EFDFBB;border-radius:12px;padding:2.5rem;border:1px solid rgba(61,26,110,0.13);">
 <div>
 <h3 style="font-family:'Cormorant Garamond',serif;font-size:1.5rem;font-weight:300;color:#2C2C2C;margin-bottom:2rem">Find us here</h3>
 <div class="contact-item">

--- a/index.html
+++ b/index.html
@@ -313,16 +313,6 @@
 </div>
 </section>
 
-<!-- HOME CTA -->
-<section class="section-dark" style="margin-top:0">
-<div class="inner" style="text-align:center">
-<p class="section-label">Ready?</p>
-<h2 style="font-family:'Cormorant Garamond',serif;font-size:clamp(1.8rem,4vw,2.8rem);font-weight:300;color:var(--gold);margin-bottom:1rem">You don't have to have it figured out to get started.</h2>
-<p style="color:var(--soft);margin-bottom:2rem">You just have to be ready to look. Book a free discovery call and let's figure out the rest together.</p>
-<a class="btn-primary" onclick="showPage('apply')">Start Here</a>
-</div>
-</section>
-
 <section style="background:#3D1A6E;padding:6rem 2rem;text-align:center;border-top:1px solid rgba(61,26,110,0.2);">
 <div style="max-width:700px;margin:0 auto;">
 <p style="font-size:0.65rem;letter-spacing:0.35em;text-transform:uppercase;color:var(--violet);margin-bottom:1.5rem;">Your next step</p>

--- a/index.html
+++ b/index.html
@@ -363,7 +363,7 @@
 <span style="background:#a78bfa"></span>
 </div>
 </div>
-<div class="section" style="padding-top:0">
+<div class="section" style="padding-top:2.5rem;margin-top:1.5rem">
 <div class="bio-block" style="border:none;padding:0;margin-bottom:2rem;background:transparent;text-align:center;font-size:1.15rem;font-style:italic;color:var(--gold)">"You don't need more insight. You need the thing underneath the insight to actually change."</div>
 <div class="about-grid">
 <div class="about-card scott">
@@ -380,7 +380,7 @@
 <p>Cait didn't build this from a textbook or a training program. She built it from the inside — learning how to rewire her own worth and beliefs while she was still living inside the thing that was testing them. That's where her tools come from. And it's why they actually work.</p>
 </div>
 </div>
-<div class="bio-block" style="margin-top:2rem;border-left-color:var(--gold);text-align:center"><strong style="color:var(--gold);font-size:0.72rem;letter-spacing:0.2em;text-transform:uppercase">Together</strong><br><br>
+<div class="bio-block" style="margin-top:3rem;border-left-color:var(--gold);text-align:center"><strong style="color:var(--gold);font-size:0.72rem;letter-spacing:0.2em;text-transform:uppercase">Together</strong><br><br>
 Two coaches. One client. No blind spots.<br><br>
 Scott tracks what keeps repeating in your story. Cait listens for what's underneath it. When we work together, nothing gets missed — because what looks like a behavior pattern to one of us looks like a language pattern to the other. You get both views at the same time.</div>
 <div style="text-align:center;margin-top:3rem">
@@ -413,7 +413,7 @@ Scott tracks what keeps repeating in your story. Cait listens for what's underne
 <span style="background:#a78bfa"></span>
 </div>
 </div>
-<div class="section" style="padding-top:0">
+<div class="section" style="padding-top:2.5rem;margin-top:1.5rem">
 <div class="service-card s1">
 <p class="service-label" style="color:var(--gold)">Focused Session</p>
 <h2>Pattern Break Intensive</h2>


### PR DESCRIPTION
## What's in this PR

- **Service packages** — removed all time frames (90-minute, 6–8 week, 10–12 week) from labels, descriptions, and FAQ
- **Contact page** — wrapped both columns in a Dutch White card so all text is legible against the aurora background
- **FAQ page** — numbered questions with gold counters, violet question text, gray indented answers with gold left border
- **About + Services spacing** — added gap between the header card and content card on both pages so sections look distinct instead of merged
- **Home page** — removed the "You don't have to have it figured out to get started" box; page now flows straight to the dark "I'm ready to help you" closing section

## Test checklist
- [ ] Services page — no time references anywhere
- [ ] Contact page — text readable on both sides
- [ ] FAQ page — questions numbered, visually distinct from answers
- [ ] About page — header card and Scott/Cait card have visible gap
- [ ] Services page — header card and service cards have visible gap
- [ ] Home page — only the dark CTA section at the bottom, no beige box above it

https://claude.ai/code/session_018Q8bfC8eVgv76jRryYBPrj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Q8bfC8eVgv76jRryYBPrj)_