### PR TITLE
Home page copy update: hero, Who This Is For, How It Works

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,9 +270,9 @@
 <div class="hero-planet fade-up" style="width:0px;height:0px;display:none">
 <img alt="Shining Clarity Coaching Logo" src="data:image/png;base64,/9j/4QBzRXhpZgAATU0AKgAAAAgABQEAAAQAAAABAAACTgEBAAQAAAABAAACJgExAAIAAAAHAAAASgEyAAIAAAAUAAAAUYdpAAQAAAABAAAAZQAAAABHb29nbGUAMjA" style="width:100%;height:100%;"/>
 </div>
-<p class="hero-eyebrow fade-up-2" style="font-size:clamp(3.2rem,8vw,6.2rem);line-height:1.1;">Shining Clarity Coaching<br><span style="font-size:clamp(1.3rem,3vw,1.9rem);letter-spacing:0.25em;color:var(--violet)">Scott &amp; Cait</span></p>
-<h1 class="hero-title fade-up-2"><span style="color:#c9a84c;">You already know what to do.</span></h1>
-<p class="fade-up-2" style="font-size:0.9rem;color:rgba(232,223,200,0.9);margin-top:0.6rem;margin-bottom:0;line-height:1.75;max-width:560px;">The real issue is what's pulling you back before you can get there.</p>
+<p class="fade-up-2" style="font-size:0.72rem;letter-spacing:0.2em;color:rgba(201,169,110,0.85);margin-bottom:1.2rem;">For the person who keeps ending up in the same place — no matter how hard they try not to.</p>
+<h1 class="hero-title fade-up-2">You're not stuck because you haven't learned enough.</h1>
+<p class="fade-up-2" style="font-size:0.9rem;color:rgba(232,223,200,0.9);margin-top:0.6rem;margin-bottom:0;line-height:1.75;max-width:580px;">You've tried. You've read the books. Done the work. Sometimes you catch yourself in the moment, sometimes only after — or only when the consequences show up. Either way, that's not a knowledge problem. That's a belief problem. And that's exactly what we fix.</p>
 
 <div class="dot-divider fade-up-3">
 <span style="background:#f43f5e"></span>
@@ -283,12 +283,45 @@
 <span style="background:#a78bfa"></span>
 <span style="background:#f43f5e"></span>
 </div>
-<p class="hero-tagline fade-up-3">That's exactly what we fix.</p>
-<p class="fade-up-3" style="font-size:0.88rem;color:rgba(232,223,200,0.78);margin-top:0.5rem;margin-bottom:0;line-height:1.8;max-width:540px;">With two experienced coaches working together in every session, nothing gets missed. You'll finally understand why it keeps happening — and walk away with clear, practical tools to stop it.</p>
+<p class="fade-up-3" style="font-size:0.88rem;color:rgba(232,223,200,0.78);margin-top:0.5rem;margin-bottom:0;line-height:1.8;max-width:560px;">At Shining Clarity Coaching, we help you understand the assumption or fear your brain is using — so you're no longer stuck reacting from it.</p>
 
 <div class="hero-buttons fade-up-4">
 <a class="btn-primary" onclick="showPage('apply')">Start Here</a>
 <a class="btn-outline" onclick="showPage('about')">Meet Scott &amp; Cait</a>
+</div>
+</section>
+
+<!-- WHO THIS IS FOR -->
+<section class="section">
+<p class="section-label">Is This You?</p>
+<h2>Who This Is For</h2>
+<p><strong>This is for you if:</strong></p>
+<ul style="list-style:none;padding:0;margin:0.5rem 0 2rem;border-left:2px solid rgba(201,169,110,0.4);padding-left:1.4rem">
+<li style="color:#555;font-size:0.94rem;line-height:1.9;margin-bottom:0.8rem">You've done therapy, read the books, tried the methods — and you're still circling back to the same place</li>
+<li style="color:#555;font-size:0.94rem;line-height:1.9;margin-bottom:0.8rem">You can see yourself doing it. Sometimes mid-loop. And you still can't stop it.</li>
+<li style="color:#555;font-size:0.94rem;line-height:1.9;margin-bottom:0.8rem">You're not in crisis. You're functional, self-aware, motivated — and completely exhausted by the fact that none of it is working</li>
+<li style="color:#555;font-size:0.94rem;line-height:1.9;margin-bottom:0.8rem">The pattern shows up in more than one area — same dynamic in relationships, work, money, decisions — like it's following you</li>
+<li style="color:#555;font-size:0.94rem;line-height:1.9;margin-bottom:0">Part of you suspects the problem isn't the situation. It's something deeper. You just don't know what.</li>
+</ul>
+<p><strong>This is NOT for you if:</strong></p>
+<ul style="list-style:none;padding:0;margin:0.5rem 0 0;border-left:2px solid rgba(61,26,110,0.25);padding-left:1.4rem">
+<li style="color:#555;font-size:0.94rem;line-height:1.9;margin-bottom:0.8rem">You're looking for someone to tell you what to do</li>
+<li style="color:#555;font-size:0.94rem;line-height:1.9;margin-bottom:0.8rem">You want coping tools without understanding why you need them</li>
+<li style="color:#555;font-size:0.94rem;line-height:1.9;margin-bottom:0">You're not willing to look at the belief underneath the behavior</li>
+</ul>
+</section>
+
+<!-- HOW IT WORKS -->
+<section class="section-dark">
+<div class="inner">
+<p class="section-label">The Process</p>
+<h2>How It Works</h2>
+<p>Most self-improvement skips a step.</p>
+<p>You learn a new strategy. You apply it. It works — until it doesn't. Until the situation gets hard enough, or familiar enough, that your brain goes right back to what it knows.</p>
+<p>That's because strategy doesn't touch belief.</p>
+<p>What we do is different. We go underneath the behavior to find the assumption or fear your brain has been operating from — sometimes for decades. Once you can see it clearly, it loses its grip.</p>
+<p>Depending on where you are and what you need, you'll either walk away with a clear understanding of the loop you're in and the belief driving it — or we go further and work together to actively rewire it, with the tools, steps, and support to change it at the root.</p>
+<p>Either way, you leave knowing something you didn't before. And that changes everything.</p>
 </div>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -271,8 +271,8 @@
 <img alt="Shining Clarity Coaching Logo" src="data:image/png;base64,/9j/4QBzRXhpZgAATU0AKgAAAAgABQEAAAQAAAABAAACTgEBAAQAAAABAAACJgExAAIAAAAHAAAASgEyAAIAAAAUAAAAUYdpAAQAAAABAAAAZQAAAABHb29nbGUAMjA" style="width:100%;height:100%;"/>
 </div>
 <p class="hero-eyebrow fade-up-2" style="font-size:clamp(3.2rem,8vw,6.2rem);line-height:1.1;">Shining Clarity Coaching<br><span style="font-size:clamp(1.3rem,3vw,1.9rem);letter-spacing:0.25em;color:var(--violet)">Scott &amp; Cait</span></p>
-<h1 class="hero-title fade-up-2"><span style="color:#c9a84c;">Stop the cycle.</span></h1>
-<p class="fade-up-2" style="font-size:0.85rem;letter-spacing:0.2em;color:rgba(232,223,200,0.85);margin-top:0.5rem;margin-bottom:0;text-transform:uppercase;">For the person who's done the work and still can't make it stop.</p>
+<h1 class="hero-title fade-up-2"><span style="color:#c9a84c;">You already know what to do.</span></h1>
+<p class="fade-up-2" style="font-size:0.9rem;color:rgba(232,223,200,0.9);margin-top:0.6rem;margin-bottom:0;line-height:1.75;max-width:560px;">The real issue is what's pulling you back before you can get there.</p>
 
 <div class="dot-divider fade-up-3">
 <span style="background:#f43f5e"></span>
@@ -283,7 +283,8 @@
 <span style="background:#a78bfa"></span>
 <span style="background:#f43f5e"></span>
 </div>
-<p class="hero-tagline fade-up-3">You've done the work. Now let's find what's underneath it.</p>
+<p class="hero-tagline fade-up-3">That's exactly what we fix.</p>
+<p class="fade-up-3" style="font-size:0.88rem;color:rgba(232,223,200,0.78);margin-top:0.5rem;margin-bottom:0;line-height:1.8;max-width:540px;">With two experienced coaches working together in every session, nothing gets missed. You'll finally understand why it keeps happening — and walk away with clear, practical tools to stop it.</p>
 
 <div class="hero-buttons fade-up-4">
 <a class="btn-primary" onclick="showPage('apply')">Start Here</a>

--- a/quiz.html
+++ b/quiz.html
@@ -483,7 +483,7 @@ function submitEmailCapture(e, loopKey) {
   fetch('https://formspree.io/f/mdapbnlo', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-    body: JSON.stringify({ email: email, loop: loopKey, source: 'quiz-notify-me' })
+    body: JSON.stringify({ email: email, loop: LOOPS[loopKey].name, source: 'quiz-notify-me' })
   }).finally(() => {
     form.style.display = 'none';
     document.getElementById('email-note').style.display = 'block';


### PR DESCRIPTION
## What's in this PR

Three changes that didn't make it into the previous merge:

- **Loop name fix** — Formspree email capture now sends the full loop name (e.g. "The Avoidance Loop") instead of just the letter code
- **Hero copy** — New eyebrow, headline, subheadline, and supporting line per brief
- **Two new home page sections** — "Who This Is For" (with is/is-not lists) and "How It Works", inserted between the hero and the existing Dual Coach section

No design or CSS changes — text content only on the new sections.

## Test plan
- [ ] Check hero on shiningclaritycoaching.com reads the new copy
- [ ] Scroll past hero — confirm "Who This Is For" and "How It Works" sections appear before the Dual Coach section
- [ ] Take the quiz and submit a Notify Me email — confirm Formspree email shows full loop name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Q8bfC8eVgv76jRryYBPrj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Q8bfC8eVgv76jRryYBPrj)_