### PR TITLE
Remove bold weight from hero top line

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@
 <div class="hero-planet fade-up" style="width:0px;height:0px;display:none">
 <img alt="Shining Clarity Coaching Logo" src="data:image/png;base64,/9j/4QBzRXhpZgAATU0AKgAAAAgABQEAAAQAAAABAAACTgEBAAQAAAABAAACJgExAAIAAAAHAAAASgEyAAIAAAAUAAAAUYdpAAQAAAABAAAAZQAAAABHb29nbGUAMjA" style="width:100%;height:100%;"/>
 </div>
-<p class="fade-up-2" style="font-size:1.3rem;letter-spacing:0.2em;color:#FDF6EC;margin-bottom:1.2rem;font-weight:300;">For the person who keeps ending up in the same place — no matter how hard they try not to.</p>
+<p class="fade-up-2" style="font-size:1.3rem;letter-spacing:0.2em;color:#FDF6EC;margin-bottom:1.2rem;font-weight:300;font-family:'Cormorant Garamond',serif;">For the person who keeps ending up in the same place — no matter how hard they try not to.</p>
 <h1 class="hero-title fade-up-2">You're not stuck because you haven't learned enough.</h1>
 <p class="fade-up-2" style="font-size:0.9rem;color:#FDF6EC;margin-top:0.6rem;margin-bottom:0;line-height:1.75;max-width:580px;">You've tried. You've read the books. Done the work. Sometimes you catch yourself in the moment, sometimes only after — or only when the consequences show up. Either way, that's not a knowledge problem. That's a belief problem. And that's exactly what we fix.</p>
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <meta name="description" content="Shining Clarity Coaching helps self-aware people break the patterns holding them back and create lasting change at the belief level."/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>Shining Clarity Coaching — You can change anything. Start with the pattern holding you back.</title>
-<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;1,300;1,400&amp;family=Lora:ital,wght@0,400;0,500;1,400&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;1,300;1,400&amp;family=Lora:ital,wght@0,300;0,400;0,500;1,400&amp;display=swap" rel="stylesheet"/>
 <style>
   :root {
     --cosmos: #f7efe3;
@@ -309,7 +309,7 @@
 <div class="hero-planet fade-up" style="width:0px;height:0px;display:none">
 <img alt="Shining Clarity Coaching Logo" src="data:image/png;base64,/9j/4QBzRXhpZgAATU0AKgAAAAgABQEAAAQAAAABAAACTgEBAAQAAAABAAACJgExAAIAAAAHAAAASgEyAAIAAAAUAAAAUYdpAAQAAAABAAAAZQAAAABHb29nbGUAMjA" style="width:100%;height:100%;"/>
 </div>
-<p class="fade-up-2" style="font-size:1.3rem;letter-spacing:0.2em;color:#FDF6EC;margin-bottom:1.2rem;">For the person who keeps ending up in the same place — no matter how hard they try not to.</p>
+<p class="fade-up-2" style="font-size:1.3rem;letter-spacing:0.2em;color:#FDF6EC;margin-bottom:1.2rem;font-weight:300;">For the person who keeps ending up in the same place — no matter how hard they try not to.</p>
 <h1 class="hero-title fade-up-2">You're not stuck because you haven't learned enough.</h1>
 <p class="fade-up-2" style="font-size:0.9rem;color:#FDF6EC;margin-top:0.6rem;margin-bottom:0;line-height:1.75;max-width:580px;">You've tried. You've read the books. Done the work. Sometimes you catch yourself in the moment, sometimes only after — or only when the consequences show up. Either way, that's not a knowledge problem. That's a belief problem. And that's exactly what we fix.</p>
 


### PR DESCRIPTION
## Summary
- Adds Lora 300 weight to the Google Fonts load so the browser has a genuine light weight to render
- Sets `font-weight:300` on the hero's top paragraph ("For the person who keeps ending up in the same place…") so it sits lighter and flows with the rest of the page instead of reading as bold

## Test plan
- [ ] Load the home page and confirm the top hero line no longer looks heavier than the surrounding text
- [ ] Confirm the gold h1 heading and the paragraph below it are visually unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01AopWRqKbZYwaKhscAPiwuo)_