### PR TITLE
Replace Terms & Conditions with full legal document

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,8 @@
   .legal-section { margin-bottom:2.5rem; }
   .legal-section h3 { font-size:0.72rem; letter-spacing:0.25em; text-transform:uppercase; color:var(--violet); margin-bottom:0.8rem; }
   .legal-section p { color:var(--soft); font-size:0.9rem; line-height:1.9; }
+  .legal-section ul { list-style:disc; padding-left:1.5rem; color:var(--soft); font-size:0.9rem; line-height:1.9; margin:0.5rem 0 1rem; }
+  .legal-section ul li { margin-bottom:0.4rem; }
   /* FOOTER */
   footer { background:#0f0520; border-top:1px solid rgba(61,26,110,0.2); padding:3rem 2rem; text-align:center; }
   .footer-logo { font-family:'Cormorant Garamond',serif; font-size:1.4rem; font-weight:300; letter-spacing:0.15em; color:var(--star); margin-bottom:0.5rem; }
@@ -834,15 +836,164 @@ Scott tracks what keeps repeating in your story. Cait listens for what's underne
 <div class="legal-page">
 <p class="section-label">Legal</p>
 <h2>Terms &amp; Conditions</h2>
-<p class="last-updated">Last updated: 2026</p>
-<div class="legal-section"><h3>1. About Shining Clarity Coaching</h3><p>Shining Clarity Coaching is a life coaching practice operated by Scott &amp; Cait. By accessing our website or engaging our services, you agree to these terms.</p></div>
-<div class="legal-section"><h3>2. Coaching vs. Therapy</h3><p>Shining Clarity Coaching is not a licensed therapy, counseling, or mental health service. Scott &amp; Cait are not licensed therapists, psychologists, or medical professionals.</p></div>
-<div class="legal-section"><h3>3. Our Services</h3><p>We offer: Free Discovery Calls, Pattern Break Intensive ($197), Loop Breaker Method ($797), and Identity Rewire Experience ($1,997). All services are delivered virtually.</p></div>
-<div class="legal-section"><h3>4. Payments &amp; Refunds</h3><p>Payment is required to secure your booking. We offer a full refund if you cancel before your first session. If you cancel within 48 hours of a session, we'll reschedule instead of charging.</p></div>
-<div class="legal-section"><h3>5. Results Disclaimer</h3><p>Individual results may vary. Shining Clarity Coaching does not guarantee specific outcomes. Your results depend on your commitment, openness, and willingness to do the work.</p></div>
-<div class="legal-section"><h3>6. Confidentiality</h3><p>What you share in sessions is held in confidence. We will not share your personal information with third parties except where required by law.</p></div>
-<div class="legal-section"><h3>7. Our Right to End a Coaching Relationship</h3><p>Shining Clarity Coaching reserves the right to discontinue services with any client at any time if we believe the coaching relationship is not a good fit or if we cannot serve them effectively.</p></div>
-<div class="legal-section"><h3>8. Contact</h3><p>Questions? Reach out at hello@shiningclarity.com</p></div>
+<p class="last-updated">Last Updated: June 24, 2026</p>
+<p>These Terms and Conditions ("Terms") govern your access to and use of the services provided by Shining Clarity Coaching ("SCC," "we," "us," or "our"), a life coaching practice registered in Montana, United States, operating at shiningclaritycoaching.com. By engaging with our services in any form — including but not limited to visiting our website, booking a session, or participating in coaching — you agree to be bound by these Terms in full.</p>
+<p>If you do not agree with any part of these Terms, you must not access or use our services.</p>
+<p>Questions? Contact us at: <a href="mailto:scott.cait@shiningclaritycoaching.com" style="color:var(--violet)">scott.cait@shiningclaritycoaching.com</a> | (406) 662-4066</p>
+
+<div class="legal-section">
+<h3>1. Nature of Services — What We Are and Are Not</h3>
+<p>Shining Clarity Coaching (SCC) is a life coaching practice. We are not licensed therapists, psychologists, psychiatrists, social workers, or medical professionals, and we do not act in any such capacity. Life coaching is a distinct profession that focuses on identifying patterns, shifting thinking, and supporting clients in creating intentional change in their lives.</p>
+<p>The dual-coach model at SCC pairs two coaches — one focused on behavioral patterns and one focused on cognitive patterns, neuroplasticity, and belief work — to work with clients simultaneously. This is still coaching, not therapy.</p>
+<p>Nothing communicated through our website, sessions, materials, or any other form of contact constitutes medical advice, mental health treatment, psychological counseling, legal advice, or financial advice.</p>
+</div>
+
+<div class="legal-section">
+<h3>2. Not a Substitute for Professional Care</h3>
+<p>Our services are not a replacement for professional mental health treatment, medical care, legal counsel, or any other licensed professional service. If you are experiencing a mental health crisis, suicidal ideation, active trauma symptoms, severe depression, anxiety disorders, or any condition requiring clinical intervention, please seek qualified professional help immediately.</p>
+<p>Crisis and mental health resources:</p>
+<ul><li>National Crisis Line: Call or text <strong>988</strong></li><li>Emergency services: <strong>911</strong></li><li>SAMHSA National Helpline: <strong>1-800-662-4357</strong></li><li>Psychology Today therapist finder: psychologytoday.com</li></ul>
+<p>SCC reserves the right to decline or discontinue services with any client whose needs exceed the scope of life coaching. In such cases, we will communicate this directly and, where appropriate, offer referrals.</p>
+</div>
+
+<div class="legal-section">
+<h3>3. Scope of Coaching Services</h3>
+<p>SCC's services are designed for growth-oriented adults who are past acute crisis and are seeking to identify and shift the root belief patterns that are preventing meaningful change. Our work includes:</p>
+<ul><li>Identifying cognitive distortions and thinking patterns</li><li>Neuroplasticity-based belief rewiring</li><li>Behavioral pattern recognition and analysis</li><li>Worthiness and self-concept work</li><li>Goal clarification and forward-focused strategy</li></ul>
+<p>Our services do not include diagnosis of any mental health condition, treatment of trauma, clinical intervention, or any service requiring a professional license. The scope of our work is explicitly forward-focused and non-clinical.</p>
+</div>
+
+<div class="legal-section">
+<h3>4. Client Responsibility and Independent Decision-Making</h3>
+<p>Coaching is a collaborative process — not a directive one. SCC provides frameworks, insight, reflection, and support. You retain full and sole responsibility for every decision you make and every action you take, during and after your engagement with us.</p>
+<p>By engaging with SCC's services, you expressly acknowledge and agree that:</p>
+<ul><li>You are an autonomous adult capable of exercising your own judgment. No insight, framework, or guidance offered during coaching removes your personal responsibility to evaluate information critically and make decisions appropriate for your own life.</li><li>SCC is not responsible for the outcome of any decision you make or action you take — whether or not that decision was influenced by your coaching experience.</li><li>Coaching does not tell you what to do. If you choose to act on something discussed in a session, that choice is yours. SCC assumes no liability for consequences that result from your choices.</li><li>You will provide accurate and honest information about yourself to the extent it is relevant to the coaching relationship.</li><li>You will communicate openly if the coaching relationship is not serving you, or if circumstances change in ways that affect your ability to participate.</li><li>You will seek licensed professional support if your needs exceed the scope of coaching.</li></ul>
+</div>
+
+<div class="legal-section">
+<h3>5. No Guaranteed Results</h3>
+<p>Life coaching is an individualized, collaborative process. Results vary significantly from person to person and are directly tied to the effort, consistency, honesty, and willingness to do the work that each client brings to the process.</p>
+<p>SCC makes no guarantees, representations, or warranties — express or implied — regarding specific outcomes, timelines, or transformations. Any testimonials or case examples shared in our marketing materials reflect individual results and are not promises of what you will achieve.</p>
+<p>Coaching is not a passive experience. Progress requires that you:</p>
+<ul><li>Show up consistently and engage honestly with the process</li><li>Complete any exercises, reflections, or practices discussed in sessions</li><li>Be open to examining patterns, beliefs, and behaviors that may be uncomfortable</li><li>Take responsibility for implementing changes in your own life</li></ul>
+</div>
+
+<div class="legal-section">
+<h3>6. Eligibility</h3>
+<p>Our services and digital products are available only to individuals who are 18 years of age or older. By engaging with SCC or purchasing our materials, you represent that you meet this age requirement.</p>
+<p>Our services are intended for individuals who are not in active psychiatric crisis. If you are currently under the care of a mental health professional for a serious condition, we recommend disclosing this at intake and obtaining clearance from your provider before beginning coaching. SCC reserves the right to decline services or sales to any individual at our sole discretion.</p>
+</div>
+
+<div class="legal-section">
+<h3>7. Confidentiality and Its Limits</h3>
+<p>We treat the information you share in one-on-one coaching sessions with care and discretion. We do not share client information with third parties except in the following circumstances:</p>
+<ul><li>You provide explicit written consent for us to share specific information.</li><li>We are required by law to disclose information (for example, if we receive a valid legal subpoena or court order).</li><li>We have a reasonable belief that you or another person is in imminent danger of harm. In such cases, we may contact appropriate emergency services or authorities.</li></ul>
+<p><strong>Group Coaching Exceptions:</strong> If you participate in an SCC group coaching program, community forum, or group call, you acknowledge that privacy cannot be guaranteed by SCC. You agree to maintain strict confidentiality regarding the personal information, identities, and stories shared by other group participants.</p>
+<p><strong>Legal Status:</strong> Life coaches are not bound by the same confidentiality laws as licensed therapists (such as HIPAA). While we are committed to discretion and professionalism, we are not legally protected providers for the purposes of privileged communication.</p>
+</div>
+
+<div class="legal-section">
+<h3>8. Booking, Payment, and Refund Policy</h3>
+<p><strong>Booking:</strong> Sessions are booked through our designated scheduling system. Booking a session constitutes your acceptance of these Terms.</p>
+<p><strong>Payment:</strong> Payment is due at the time of booking unless otherwise agreed in writing. We accept Visa, Mastercard, Google Pay, and Apple Pay. All prices are in US dollars. Sales tax will be applied where required by law.</p>
+<p><strong>Installment Rules:</strong> For clients utilizing an approved installment plan, all scheduled payments must be fully processed and cleared at least twenty-four (24) hours prior to the scheduled session time. If an installment payment fails or is late, SCC reserves the right to automatically pause services and cancel the upcoming session.</p>
+<p><strong>Financial Commitment:</strong> Choosing an installment plan represents a legally binding commitment to pay the full purchase price of the selected coaching package. You are not permitted to cancel future installments or walk away from the financial obligation early, regardless of whether you choose to use all the sessions in your package.</p>
+<p><strong>Early Termination &amp; Balance Acceleration:</strong> Your installment plan is a financing agreement for the total cost of your coaching package, not a flexible pay-as-you-go subscription. If you choose to cancel early, or if your account is terminated due to a breach of these Terms, the entire remaining balance will become immediately due and payable in full.</p>
+<p><strong>Refund Policy:</strong></p>
+<ul><li><em>Completed Services:</em> Sessions that have already been completed are strictly non-refundable.</li><li><em>Digital &amp; Physical Products:</em> All sales of workbooks, digital products, and downloadable materials are 100% final. No refunds, returns, or exchanges will be issued once purchase or download access is completed.</li><li><em>Unused 1:1 Sessions:</em> If you have paid upfront for a package and have remaining sessions that have not yet occurred, you may request a refund for those unused sessions. Refunds for unused sessions are processed at the standard single-session rate, removing any package discounts if the remaining sessions fall below the package minimum. Requests must be submitted in writing to scott.cait@shiningclaritycoaching.com.</li></ul>
+<p><strong>Cancellation &amp; No-Show Policy:</strong> Cancellations made at least 24 hours before a scheduled session may be rescheduled at our discretion. Cancellations made less than 24 hours before a session may be forfeited without credit. If a client fails to show up within fifteen (15) minutes of the scheduled start time, the session is marked as a No-Show and is forfeited without credit. After 3 consecutive rescheduled appointments, the 4th is a forfeited appointment without credit.</p>
+</div>
+
+<div class="legal-section">
+<h3>9. Intellectual Property and Digital Licensing</h3>
+<p>All content created or provided by Shining Clarity Coaching — including session frameworks, methodologies, workbooks, digital products, downloadable PDFs, written materials, website content, tools, assessments, and coaching approaches — is the exclusive intellectual property of SCC and is protected under applicable copyright and trademark law.</p>
+<p><strong>Limited Single-User License:</strong> You are granted a limited, personal, non-exclusive, non-transferable license to use SCC materials for your own private, individual growth and reference only.</p>
+<p><strong>Prohibited Uses:</strong></p>
+<ul><li>Reproduce, copy, or distribute SCC content or workbook files to third parties</li><li>Rebrand, relabel, or present SCC frameworks or methodologies as your own work</li><li>Use SCC content for commercial purposes, including coaching, teaching, selling, or packaging into your own products or services</li><li>Share SCC materials publicly, including on social media, shared cloud drives, websites, or in group settings, without explicit written consent</li></ul>
+<p>What you personally discover, create, or develop about yourself during the coaching process belongs to you. SCC claims ownership only over the frameworks, tools, and methodologies we bring to the process.</p>
+</div>
+
+<div class="legal-section">
+<h3>10. Testimonials and Marketing</h3>
+<p>If you choose to provide a testimonial or participate in a case study, you grant SCC a non-exclusive, royalty-free license to use your words (and, if you consent separately, your name or likeness) in our marketing materials. We will never share your full name, identifying details, or session content in any public-facing material without your explicit written consent. Testimonials may be shared in anonymized or first-name-only form with your prior agreement. You may withdraw consent for future use of your testimonial at any time by contacting us in writing.</p>
+</div>
+
+<div class="legal-section">
+<h3>11. Website Use and Acceptable Conduct</h3>
+<p>By accessing shiningclaritycoaching.com or entering our digital coaching environments, you agree not to:</p>
+<ul><li>Use the site, products, or materials for any unlawful purpose or in violation of these Terms</li><li>Attempt to gain unauthorized access to any part of the website, user accounts, digital workbooks, or community platforms</li><li>Share, forward, or publicly post direct digital download links, access codes, or login credentials provided by SCC</li><li>Transmit harmful, malicious, or disruptive code, content, or conduct</li><li>Impersonate SCC, its coaches, or any other user</li><li>Scrape, harvest, or collect data from our website or community platforms without written permission</li><li>Use our website, brand, content, or workbooks to compete with us or for unauthorized commercial purposes</li></ul>
+</div>
+
+<div class="legal-section">
+<h3>12. Third-Party Links and Tools</h3>
+<p>Our website or services may reference or link to third-party platforms, tools, or resources such as scheduling software, payment processors, or external reading. These links are provided for convenience only. SCC does not endorse, control, or assume responsibility for the content, privacy practices, or reliability of any third-party platform. Your use of third-party tools or services is governed by their own terms and policies.</p>
+</div>
+
+<div class="legal-section">
+<h3>13. Privacy</h3>
+<p>We collect and use personal information in accordance with our Privacy Policy, which is incorporated into these Terms by reference. By using our services, you consent to the collection and use of your information as described in our Privacy Policy. We do not sell your personal information to third parties.</p>
+</div>
+
+<div class="legal-section">
+<h3>14. Disclaimer of Warranties</h3>
+<p style="text-transform:uppercase;font-size:0.85rem;">Our services and products are provided "as is" and "as available" without warranties of any kind, either express or implied. To the fullest extent permitted by law, SCC disclaims all warranties, including but not limited to implied warranties of merchantability, fitness for a particular purpose, and non-infringement. We do not warrant that our services or digital products will meet your specific needs, that any particular result will be achieved, or that our website will be uninterrupted or error-free.</p>
+</div>
+
+<div class="legal-section">
+<h3>15. Limitation of Liability</h3>
+<p style="text-transform:uppercase;font-size:0.85rem;">To the maximum extent permitted by applicable law, SCC and its coaches, employees, contractors, and affiliates shall not be liable for any indirect, incidental, special, consequential, or punitive damages — including but not limited to loss of income, emotional distress, loss of data, or any other intangible losses — arising out of or in connection with your use of our services or any decisions or actions you take as a result of coaching. In no event shall SCC's total liability to you exceed the total amount paid by you to SCC in the three (3) months preceding the event giving rise to the claim.</p>
+</div>
+
+<div class="legal-section">
+<h3>16. Indemnification</h3>
+<p>You agree to indemnify, defend, and hold harmless Shining Clarity Coaching and its coaches, contractors, agents, and representatives from and against any and all claims, damages, losses, costs, or expenses (including reasonable legal fees) arising out of or related to:</p>
+<ul><li>Your use of or inability to use our services or products</li><li>Your violation of these Terms</li><li>Your violation of any third-party rights</li><li>Any decisions or actions you take — or fail to take — as a result of coaching or using our materials</li><li>Any false or misleading information you provide to SCC</li></ul>
+</div>
+
+<div class="legal-section">
+<h3>17. Termination</h3>
+<p>Either party may end the coaching relationship at any time. You may discontinue services by providing written notice to SCC.</p>
+<p>SCC reserves the right to terminate the coaching relationship without prior notice if you violate any provision of these Terms, fail to clear scheduled installment payments within 24 hours of a session, engage in abusive or harassing conduct, violate confidentiality of group participants, share or redistribute our proprietary materials, are consistently unwilling to engage with the coaching process in good faith, or if your needs exceed the appropriate scope of life coaching.</p>
+<p><strong>Financial Obligations Upon Termination:</strong></p>
+<ul><li><em>If You Terminate:</em> You may request a refund for unused upfront prepaid sessions per the Refund Policy. However, if you are on an active installment plan, termination does not relieve you of your financial obligation. The remaining balance accelerates and becomes immediately due in full.</li><li><em>If SCC Terminates for Cause:</em> You forfeit all fees paid. Any remaining unpaid installments accelerate and become immediately due. SCC retains sole discretion over whether any partial refund will be offered.</li><li><em>If SCC Terminates for Scope of Care:</em> You will be refunded for any unused, upfront prepaid sessions on a pro-rata basis, and future automated installment payments for unrendered services will be canceled.</li></ul>
+</div>
+
+<div class="legal-section">
+<h3>18. Governing Law and Dispute Resolution</h3>
+<p>These Terms shall be governed by and construed in accordance with the laws of the State of Montana, without regard to its conflict of law provisions. In the event of a dispute, the parties agree to first attempt resolution informally by contacting SCC directly. If informal resolution is not reached within 30 days, the parties agree to submit to binding arbitration in accordance with the rules of the American Arbitration Association, to be conducted in Montana. You agree that any claims must be brought individually and not as part of a class action or class arbitration.</p>
+</div>
+
+<div class="legal-section">
+<h3>19. Modifications to These Terms</h3>
+<p>We reserve the right to update or modify these Terms at any time. Changes will be reflected by updating the "Last Updated" date at the top of this document. It is your responsibility to review these Terms periodically. Your continued use of our services after any modifications constitutes your acceptance of the revised Terms.</p>
+</div>
+
+<div class="legal-section">
+<h3>20. Entire Agreement</h3>
+<p>These Terms, together with our Privacy Policy and any written service agreement signed between you and SCC, constitute the entire agreement between you and Shining Clarity Coaching and supersede all prior communications, understandings, or agreements related to the subject matter herein. If any provision of these Terms is found to be invalid or unenforceable, the remaining provisions shall continue in full force and effect.</p>
+</div>
+
+<div class="legal-section">
+<h3>21. Contact Information</h3>
+<p>If you have questions about these Terms or our services, please reach out:</p>
+<p><strong>Shining Clarity Coaching</strong><br>
+Email: <a href="mailto:scott.cait@shiningclaritycoaching.com" style="color:var(--violet)">scott.cait@shiningclaritycoaching.com</a><br>
+Phone: (406) 662-4066<br>
+Website: shiningclaritycoaching.com<br>
+Location: Montana, United States (mailing address available upon request)</p>
+</div>
+
+<div class="legal-section">
+<h3>22. Definitions</h3>
+<ul><li><strong>Coaching</strong> — A non-clinical, forward-focused process that supports clients in identifying patterns, shifting beliefs, and creating intentional change. Coaching is not therapy, counseling, medical treatment, or any licensed professional service.</li><li><strong>Client</strong> — Any individual who engages with SCC services, books sessions, purchases digital products, or participates in coaching programs.</li><li><strong>Coach</strong> — Any individual employed or contracted by SCC to provide coaching services.</li><li><strong>Services</strong> — All offerings provided by SCC, including one-on-one coaching, group coaching, digital products, workbooks, exercises, and website content.</li><li><strong>Scope of Care</strong> — The boundaries of what SCC can ethically and legally provide, excluding therapy, diagnosis, crisis intervention, or any service requiring a professional license.</li><li><strong>Installment Plan</strong> — A financing arrangement allowing clients to pay for a coaching package over time. All installment plans represent a binding commitment to pay the full package price.</li><li><strong>Termination for Cause</strong> — Termination initiated by SCC due to violation of these Terms, non-payment, abusive conduct, digital piracy, confidentiality breaches, or other behaviors outlined in Section 17.</li><li><strong>Unused Sessions</strong> — Prepaid sessions that have not yet occurred at the time of termination or refund request.</li><li><strong>Digital Products</strong> — Any downloadable or online materials including workbooks, PDFs, exercises, and self-study tools.</li></ul>
+</div>
+
+<div class="legal-section">
+<h3>23. Client Code of Conduct</h3>
+<p>To maintain a productive, respectful, and safe coaching environment, all clients agree to:</p>
+<ul><li><strong>Respectful Communication</strong> — Communicate with SCC coaches, staff, and group participants in a respectful, non-abusive manner.</li><li><strong>Honest Participation</strong> — Provide truthful, accurate information relevant to the coaching process and communicate openly about challenges or changes in circumstances.</li><li><strong>Engagement in the Process</strong> — Attend sessions on time, complete agreed-upon work, and engage in good faith.</li><li><strong>Confidentiality in Group Settings</strong> — Maintain strict confidentiality regarding other participants' identities, stories, and personal information.</li><li><strong>Responsible Use of SCC Materials</strong> — Not copy, share, distribute, or repurpose SCC's proprietary content, workbooks, or frameworks.</li><li><strong>Technology Requirements</strong> — Maintain a stable internet connection, functioning audio/video equipment, and a private environment suitable for coaching sessions.</li><li><strong>Financial Integrity</strong> — Honor all payment commitments, including installment plans.</li><li><strong>Appropriate Scope of Care</strong> — Seek licensed professional support when needs exceed the scope of coaching.</li><li><strong>No Disruption of Group Programs</strong> — Not engage in behavior that disrupts group coaching environments.</li></ul>
+<p>By engaging with Shining Clarity Coaching's services or purchasing our products, you acknowledge that you have read, understood, and agree to be bound by these Terms and Conditions.</p>
+</div>
 </div>
 <footer>
 <div class="rainbow-bar" style="margin-bottom:2rem"></div>


### PR DESCRIPTION
Replaces the placeholder 8-section Terms & Conditions page with the full 23-section legal document from SCC_Terms_and_Conditions_Final.docx.

Includes all sections: Nature of Services, Not a Substitute for Professional Care, Scope of Services, Client Responsibility, No Guaranteed Results, Eligibility, Confidentiality, Booking/Payment/Refund Policy, Intellectual Property, Testimonials, Website Use, Third-Party Links, Privacy, Disclaimer of Warranties, Limitation of Liability, Indemnification, Termination, Governing Law, Modifications, Entire Agreement, Contact Information, Definitions, and Client Code of Conduct.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Q8bfC8eVgv76jRryYBPrj)_