### PR TITLE
Replace Start Here form with direct Setmore booking CTA

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -54,81 +54,8 @@
 <span style="background:#f43f5e"></span><span style="background:#facc15"></span><span style="background:#4ade80"></span><span style="background:#38bdf8"></span><span style="background:#a78bfa"></span>
 </div>
 </div>
-<div style="max-width:700px;margin:0 auto;padding:0 2rem 4rem">
-<div style="background:#EFDFBB;border-radius:12px;padding:2.5rem 2.5rem 2rem;border:1px solid rgba(61,26,110,0.13);margin-bottom:2rem">
-<form method="POST" action="https://formspree.io/f/mwvyazlw" name="discovery-call" onsubmit="handleSubmit(event)">
-<div class="form-group">
-<label>Your name</label>
-<input name="name" placeholder="Your full name" required="" type="text"/>
-</div>
-<div class="form-group">
-<label>Preferred pronouns</label>
-<input name="pronouns" placeholder="e.g. she/her, he/his, they/them, or other" type="text"/>
-</div>
-<div class="form-group">
-<label>Email address</label>
-<input name="email" placeholder="your@email.com" required="" type="email"/>
-</div>
-<div class="form-group">
-<label>Phone number</label>
-<input name="phone" placeholder="Your phone number" type="tel"/>
-</div>
-<div class="form-group">
-<label>What brought you to Shining Clarity Coaching today?</label>
-<textarea name="what-brought-you" placeholder="What's going on in your world right now..."></textarea>
-</div>
-<div class="form-group">
-<label>If applicable — what has you feeling most stuck, your biggest obstacle, or most unclear?</label>
-<textarea name="stuck" placeholder="Share as much or as little as you'd like..."></textarea>
-</div>
-<div class="form-group">
-<label>What have you already tried, and what got in the way?</label>
-<textarea name="tried" placeholder="Your honest answer here..."></textarea>
-</div>
-<div class="form-group">
-<label>On a scale of 1–10, how ready are you to do the work and make changes?</label>
-<div class="scale-row">
-<button class="scale-btn" onclick="selectScale(this,'readiness')" type="button">1</button>
-<button class="scale-btn" onclick="selectScale(this,'readiness')" type="button">2</button>
-<button class="scale-btn" onclick="selectScale(this,'readiness')" type="button">3</button>
-<button class="scale-btn" onclick="selectScale(this,'readiness')" type="button">4</button>
-<button class="scale-btn" onclick="selectScale(this,'readiness')" type="button">5</button>
-<button class="scale-btn" onclick="selectScale(this,'readiness')" type="button">6</button>
-<button class="scale-btn" onclick="selectScale(this,'readiness')" type="button">7</button>
-<button class="scale-btn" onclick="selectScale(this,'readiness')" type="button">8</button>
-<button class="scale-btn" onclick="selectScale(this,'readiness')" type="button">9</button>
-<button class="scale-btn" onclick="selectScale(this,'readiness')" type="button">10</button>
-</div>
-<input id="readiness-val" name="readiness" type="hidden"/>
-</div>
-<div class="form-group">
-<label>Is there anything you want us to know about you before we begin?</label>
-<textarea name="anything-else-before" placeholder="Anything at all — we're here to listen..."></textarea>
-</div>
-<div class="form-group">
-<label>Which service are you interested in?</label>
-<select name="service">
-<option value="">Select a service...</option>
-<option>Free Discovery Call</option>
-<option>Focused Session — $197</option>
-<option>Loop Breaker Method — $1,500</option>
-<option>Identity Rewire Experience — $3,500</option>
-<option>Not sure yet — help me decide</option>
-</select>
-</div>
-<div class="form-group">
-<label>Anything else you'd like to share?</label>
-<textarea name="anything-else" placeholder="This is your space..."></textarea>
-</div>
-<button class="btn-primary" style="width:100%;font-size:0.85rem;padding:1.1rem" type="submit">Send My Application ✦</button>
-<p style="text-align:center;margin-top:1rem;font-size:0.75rem;color:var(--violet)">After submitting, we'll be in touch within 48 hours.</p>
-</form>
-<div class="success-msg" id="success-msg" style="text-align:center;padding:1rem 0;display:none;">
-<div style="font-size:2rem;color:var(--gold);margin-bottom:1rem;">✦</div>
-<h3 style="font-family:'Cormorant Garamond',serif;font-size:2rem;font-weight:300;margin-bottom:0.8rem;">You're on your way.</h3>
-<p style="color:var(--soft);margin-bottom:2rem;font-size:0.95rem;">Your application has been received. We'll be in touch within 48 hours to schedule your discovery call.</p>
-</div>
-</div>
+<div style="text-align:center;padding:2rem 0 4rem">
+<a class="btn-primary" href="https://caitlyn16dl.setmore.com/" style="font-size:0.85rem;letter-spacing:0.2em;padding:1rem 3rem;">Book Your Free Discovery Call</a>
 </div>
 </main>
 <footer>


### PR DESCRIPTION
## Summary

- Removed all form fields and the form wrapper from `apply.html` (the "Start Here" page)
- Replaced with a single `btn-primary` anchor that links directly to `https://caitlyn16dl.setmore.com/` — the same Setmore URL the form previously redirected to after successful submission
- Existing button styling (`btn-primary`) and page placement are preserved

## Test plan

- [ ] Visit `/apply.html` and confirm the form is gone
- [ ] Confirm the "Book Your Free Discovery Call" button is visible and styled correctly
- [ ] Click the button and confirm it navigates to `https://caitlyn16dl.setmore.com/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqepo5gzfjfnHhoUBL6nEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aqepo5gzfjfnHhoUBL6nEs)_