### PR TITLE
Add myths-quiz.html to sitemap.xml

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -51,6 +51,13 @@
   </url>
 
   <url>
+    <loc>https://shiningclaritycoaching.com/myths-quiz.html</loc>
+    <lastmod>2026-07-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
     <loc>https://shiningclaritycoaching.com/terms.html</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>yearly</changefreq>


### PR DESCRIPTION
## Summary
- Adds `myths-quiz.html` to `sitemap.xml` (was missing after the page was merged in #46), matching the existing entry style/priority used for `quiz.html`.

## Test plan
- [ ] Confirm `sitemap.xml` validates and lists `myths-quiz.html`
- [ ] Resubmit the sitemap in Google Search Console after merge (see chat for step-by-step)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GNd7XFUExzKhTUEauXcTqW)_