### PR TITLE
Add Free Tools hub page and Loop Interrupt Card

### DIFF
--- a/about.html
+++ b/about.html
@@ -60,6 +60,7 @@
 <li><a href="/">Home</a></li>
 <li><a href="/about.html">About</a></li>
 <li><a href="/services.html">Services</a></li>
+<li><a href="/free-tools.html">Free Tools</a></li>
 <li><a href="/faq.html">FAQ</a></li>
 <li><a href="/contact.html">Contact</a></li>
 </ul>
@@ -72,6 +73,7 @@
   <a href="/" onclick="toggleMenu()">Home</a>
   <a href="/about.html" onclick="toggleMenu()">About</a>
   <a href="/services.html" onclick="toggleMenu()">Services</a>
+  <a href="/free-tools.html" onclick="toggleMenu()">Free Tools</a>
   <a href="/faq.html" onclick="toggleMenu()">FAQ</a>
   <a href="/contact.html" onclick="toggleMenu()">Contact</a>
   <a class="mobile-cta" href="/apply.html" onclick="toggleMenu()">Start Here</a>

--- a/apply.html
+++ b/apply.html
@@ -28,6 +28,7 @@
 <li><a href="/">Home</a></li>
 <li><a href="/about.html">About</a></li>
 <li><a href="/services.html">Services</a></li>
+<li><a href="/free-tools.html">Free Tools</a></li>
 <li><a href="/faq.html">FAQ</a></li>
 <li><a href="/contact.html">Contact</a></li>
 </ul>
@@ -40,6 +41,7 @@
   <a href="/" onclick="toggleMenu()">Home</a>
   <a href="/about.html" onclick="toggleMenu()">About</a>
   <a href="/services.html" onclick="toggleMenu()">Services</a>
+  <a href="/free-tools.html" onclick="toggleMenu()">Free Tools</a>
   <a href="/faq.html" onclick="toggleMenu()">FAQ</a>
   <a href="/contact.html" onclick="toggleMenu()">Contact</a>
   <a class="mobile-cta" href="/apply.html" onclick="toggleMenu()">Start Here</a>

--- a/contact.html
+++ b/contact.html
@@ -28,6 +28,7 @@
 <li><a href="/">Home</a></li>
 <li><a href="/about.html">About</a></li>
 <li><a href="/services.html">Services</a></li>
+<li><a href="/free-tools.html">Free Tools</a></li>
 <li><a href="/faq.html">FAQ</a></li>
 <li><a href="/contact.html">Contact</a></li>
 </ul>
@@ -40,6 +41,7 @@
   <a href="/" onclick="toggleMenu()">Home</a>
   <a href="/about.html" onclick="toggleMenu()">About</a>
   <a href="/services.html" onclick="toggleMenu()">Services</a>
+  <a href="/free-tools.html" onclick="toggleMenu()">Free Tools</a>
   <a href="/faq.html" onclick="toggleMenu()">FAQ</a>
   <a href="/contact.html" onclick="toggleMenu()">Contact</a>
   <a class="mobile-cta" href="/apply.html" onclick="toggleMenu()">Start Here</a>

--- a/faq.html
+++ b/faq.html
@@ -158,6 +158,7 @@
 <li><a href="/">Home</a></li>
 <li><a href="/about.html">About</a></li>
 <li><a href="/services.html">Services</a></li>
+<li><a href="/free-tools.html">Free Tools</a></li>
 <li><a href="/faq.html">FAQ</a></li>
 <li><a href="/contact.html">Contact</a></li>
 </ul>
@@ -170,6 +171,7 @@
   <a href="/" onclick="toggleMenu()">Home</a>
   <a href="/about.html" onclick="toggleMenu()">About</a>
   <a href="/services.html" onclick="toggleMenu()">Services</a>
+  <a href="/free-tools.html" onclick="toggleMenu()">Free Tools</a>
   <a href="/faq.html" onclick="toggleMenu()">FAQ</a>
   <a href="/contact.html" onclick="toggleMenu()">Contact</a>
   <a class="mobile-cta" href="/apply.html" onclick="toggleMenu()">Start Here</a>

--- a/free-tools.html
+++ b/free-tools.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>Free Tools | Quizzes & Self-Coaching Exercises | Shining Clarity Coaching</title>
+<meta name="description" content="Free quizzes and self-coaching tools from Shining Clarity Coaching. Find your loop, spot cognitive distortions, and start rewiring stuck patterns — no signup required."/>
+<link rel="canonical" href="https://shiningclaritycoaching.com/free-tools.html"/>
+<meta name="keywords" content="free coaching tools, thought record, cognitive distortion quiz, find your loop quiz, self coaching exercises"/>
+<meta property="og:title" content="Free Tools | Shining Clarity Coaching"/>
+<meta property="og:description" content="Free quizzes and self-coaching tools to help you spot the pattern that's keeping you stuck."/>
+<meta property="og:url" content="https://shiningclaritycoaching.com/free-tools.html"/>
+<meta property="og:type" content="website"/>
+<meta property="og:image" content="https://shiningclaritycoaching.com/logo.png"/>
+<meta property="og:site_name" content="Shining Clarity Coaching"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:title" content="Free Tools | Shining Clarity Coaching"/>
+<meta name="twitter:description" content="Free quizzes and self-coaching tools to help you spot the pattern that's keeping you stuck."/>
+<meta name="twitter:image" content="https://shiningclaritycoaching.com/logo.png"/>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;1,300;1,400&amp;family=Lora:ital,wght@0,300;0,400;0,500;1,400&amp;display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="/styles.css"/>
+<style>
+.tools-grid { display:grid; grid-template-columns:1fr 1fr; gap:1.5rem; margin-top:2rem; }
+@media(max-width:680px) { .tools-grid { grid-template-columns:1fr; } }
+.tool-card { background:#FFFFFF; border:1px solid rgba(61,26,110,0.12); padding:2.5rem; transition:border-color 0.3s; display:flex; flex-direction:column; }
+.tool-card:hover { border-color:rgba(61,26,110,0.3); }
+.tool-card.t1 { border-left:4px solid var(--gold); }
+.tool-card.t2 { border-left:4px solid var(--violet); }
+.tool-card.t3 { border-left:4px solid var(--blue); }
+.tool-card.t4 { border-left:4px solid var(--gold); }
+.tool-label { font-size:0.65rem; letter-spacing:0.3em; text-transform:uppercase; margin-bottom:0.6rem; color:var(--gold); }
+.tool-card h2 { font-family:'Cormorant Garamond',serif; font-size:1.6rem; font-weight:400; color:#2C2C2C; margin-bottom:0.6rem; }
+.tool-card p { color:#555555; line-height:1.7; font-size:0.92rem; margin-bottom:1.5rem; flex-grow:1; }
+</style>
+</head>
+<body>
+<canvas id="aurora-bg"></canvas>
+<nav>
+<a class="nav-logo" href="/" style="display:flex;align-items:center;gap:0.8rem"><img alt="Shining Clarity Coaching" src="/logo.png" style="height:2.5rem;width:auto;"/><span>Shining Clarity</span></a>
+<ul class="nav-links">
+<li><a href="/">Home</a></li>
+<li><a href="/about.html">About</a></li>
+<li><a href="/services.html">Services</a></li>
+<li><a href="/free-tools.html">Free Tools</a></li>
+<li><a href="/faq.html">FAQ</a></li>
+<li><a href="/contact.html">Contact</a></li>
+</ul>
+<a class="nav-cta" href="/apply.html">Start Here</a>
+<button class="hamburger" id="hamburger" aria-label="Menu" onclick="toggleMenu()">
+  <span></span><span></span><span></span>
+</button>
+</nav>
+<div class="mobile-menu" id="mobileMenu">
+  <a href="/" onclick="toggleMenu()">Home</a>
+  <a href="/about.html" onclick="toggleMenu()">About</a>
+  <a href="/services.html" onclick="toggleMenu()">Services</a>
+  <a href="/free-tools.html" onclick="toggleMenu()">Free Tools</a>
+  <a href="/faq.html" onclick="toggleMenu()">FAQ</a>
+  <a href="/contact.html" onclick="toggleMenu()">Contact</a>
+  <a class="mobile-cta" href="/apply.html" onclick="toggleMenu()">Start Here</a>
+</div>
+<main>
+<div class="rainbow-bar"></div>
+<div class="section">
+<p class="section-label">No Signup Required</p>
+<h2>Free Tools</h2>
+<div class="dot-divider" style="justify-content:flex-start">
+<span style="background:#f43f5e"></span><span style="background:#facc15"></span><span style="background:#4ade80"></span><span style="background:#38bdf8"></span><span style="background:#a78bfa"></span>
+</div>
+<p style="color:#555555;line-height:1.8;max-width:640px;margin-top:1rem">A few quick ways to see your own patterns before you ever talk to us. Everything here is free, takes a few minutes, and nothing you write leaves your device.</p>
+
+<div class="tools-grid">
+
+<div class="tool-card t1">
+<p class="tool-label">3-Minute Quiz</p>
+<h2>Find Your Loop</h2>
+<p>Discover which loop is keeping you stuck. A quick assessment that names the pattern running the show.</p>
+<a class="btn-outline" href="/quiz.html">Take the Quiz</a>
+</div>
+
+<div class="tool-card t2">
+<p class="tool-label">2-Minute Quiz</p>
+<h2>The Myths About Change</h2>
+<p>10 things almost everyone believes about change. How many are actually true? Test yourself.</p>
+<a class="btn-outline" href="/myths-quiz.html">Take the Quiz</a>
+</div>
+
+<div class="tool-card t3">
+<p class="tool-label">Interactive Quiz</p>
+<h2>Spot the Loop</h2>
+<p>10 quick stories. Can you spot the loop running the show in each one? Most people can't.</p>
+<a class="btn-outline" href="/spot-the-loop.html">Take the Quiz</a>
+</div>
+
+<div class="tool-card t4">
+<p class="tool-label">Self-Coaching Exercise</p>
+<h2>The Thought Record</h2>
+<p>Catch a thought, separate fact from story, spot the distortion, and rewrite it. Saves privately on your device.</p>
+<a class="btn-outline" href="/thought-record.html">Open the Tool</a>
+</div>
+
+</div>
+
+<div style="text-align:center;margin-top:3rem">
+<p style="color:#555555;margin-bottom:1.5rem">Ready to go deeper than a quiz can take you?</p>
+<a class="btn-primary" href="/apply.html">Start Here</a>
+</div>
+</div>
+</main>
+<footer>
+<div class="rainbow-bar" style="margin-bottom:2rem"></div>
+<div class="footer-logo" style="display:flex;align-items:center;justify-content:center;gap:0.8rem"><img alt="Shining Clarity Coaching" src="/logo.png" style="height:1.5rem;width:auto;"/><span>Shining Clarity</span></div>
+<div class="footer-quote">"You don't have to have it figured out to get started. You just have to be ready to look." — Scott &amp; Cait</div>
+<div class="footer-tag">You can change anything. Start with the pattern holding you back.</div>
+<div class="footer-legal-links">
+<a href="/terms.html">Terms &amp; Conditions</a>
+<a href="/privacy.html">Privacy Policy</a>
+</div>
+<div class="footer-copy">© 2026 Shining Clarity Coaching — Scott &amp; Cait</div>
+<div class="footer-disclaimer">Shining Clarity Coaching is a coaching practice, not a therapy or mental health service. Scott &amp; Cait are not licensed therapists, psychologists, or medical professionals.</div>
+</footer>
+<script src="/main.js"></script>
+</body>
+</html>

--- a/free-tools.html
+++ b/free-tools.html
@@ -29,6 +29,7 @@
 .tool-card.t2 { border-left:4px solid var(--violet); }
 .tool-card.t3 { border-left:4px solid var(--blue); }
 .tool-card.t4 { border-left:4px solid var(--gold); }
+.tool-card.t5 { border-left:4px solid var(--violet); }
 .tool-label { font-size:0.65rem; letter-spacing:0.3em; text-transform:uppercase; margin-bottom:0.6rem; color:var(--gold); }
 .tool-card h2 { font-family:'Cormorant Garamond',serif; font-size:1.6rem; font-weight:400; color:#2C2C2C; margin-bottom:0.6rem; }
 .tool-card p { color:#555555; line-height:1.7; font-size:0.92rem; margin-bottom:1.5rem; flex-grow:1; }
@@ -98,6 +99,13 @@
 <h2>The Thought Record</h2>
 <p>Catch a thought, separate fact from story, spot the distortion, and rewrite it. Saves privately on your device.</p>
 <a class="btn-outline" href="/thought-record.html">Open the Tool</a>
+</div>
+
+<div class="tool-card t5">
+<p class="tool-label">60-Second Reset</p>
+<h2>The Loop Interrupt Card</h2>
+<p>Spiraling right now? Three quick steps to interrupt the loop while it's still running.</p>
+<a class="btn-outline" href="/loop-interrupt.html">Interrupt It</a>
 </div>
 
 </div>

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
 <li><a href="/">Home</a></li>
 <li><a href="/about.html">About</a></li>
 <li><a href="/services.html">Services</a></li>
+<li><a href="/free-tools.html">Free Tools</a></li>
 <li><a href="/faq.html">FAQ</a></li>
 <li><a href="/contact.html">Contact</a></li>
 </ul>
@@ -73,6 +74,7 @@
   <a href="/" onclick="toggleMenu()">Home</a>
   <a href="/about.html" onclick="toggleMenu()">About</a>
   <a href="/services.html" onclick="toggleMenu()">Services</a>
+  <a href="/free-tools.html" onclick="toggleMenu()">Free Tools</a>
   <a href="/faq.html" onclick="toggleMenu()">FAQ</a>
   <a href="/contact.html" onclick="toggleMenu()">Contact</a>
   <a class="mobile-cta" href="/apply.html" onclick="toggleMenu()">Start Here</a>

--- a/loop-interrupt.html
+++ b/loop-interrupt.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The Loop Interrupt Card | Shining Clarity Coaching</title>
+<meta name="description" content="Spiraling right now? This takes 60 seconds. Three steps to interrupt the loop while it's running.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,500&family=Jost:wght@300;400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --navy: #0b0f24; --navy-2: #12173a; --violet: #3a2d6e; --violet-soft: #6a5aa8;
+    --gold: #c9a96e; --gold-bright: #D4AF6A; --ink: #e9e6f2; --ink-dim: #a9a4c4; --green: #7fc9a6;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: radial-gradient(ellipse at 50% -10%, var(--violet) 0%, var(--navy-2) 40%, var(--navy) 80%);
+    min-height: 100vh; min-height: 100dvh;
+    color: var(--ink); font-family: 'Jost', sans-serif; font-weight: 300;
+    display: flex; flex-direction: column;
+  }
+  .wrap {
+    flex: 1; max-width: 560px; width: 100%; margin: 0 auto;
+    padding: 40px 24px 60px;
+    display: flex; flex-direction: column; justify-content: center;
+  }
+  .eyebrow {
+    font-size: 11px; letter-spacing: .28em; text-transform: uppercase;
+    color: var(--gold); text-align: center; margin-bottom: 20px; font-weight: 500;
+  }
+  .screen { display: none; animation: fade .45s ease; }
+  .screen.on { display: block; }
+  @keyframes fade { from { opacity: 0; transform: translateY(10px);} to { opacity: 1; transform: none;} }
+  @media (prefers-reduced-motion: reduce){ * { animation: none !important; } }
+
+  h1, h2 {
+    font-family: 'Cormorant Garamond', serif; font-weight: 500;
+    font-size: clamp(30px, 7vw, 42px); line-height: 1.18; text-align: center; margin-bottom: 18px;
+  }
+  h1 em, h2 em { font-style: italic; color: var(--gold-bright); }
+  .sub { text-align: center; color: var(--ink-dim); font-size: 17px; line-height: 1.65; margin-bottom: 34px; }
+  .sub strong { color: var(--ink); font-weight: 500; }
+
+  .steplabel {
+    font-size: 11px; letter-spacing: .3em; text-transform: uppercase;
+    color: var(--gold); text-align: center; font-weight: 600; margin-bottom: 14px;
+  }
+
+  /* breathing pulse */
+  .pulse {
+    width: 84px; height: 84px; margin: 0 auto 30px; border-radius: 50%;
+    border: 1px solid var(--gold);
+    display: flex; align-items: center; justify-content: center;
+    animation: breathe 7s ease-in-out infinite;
+    box-shadow: 0 0 30px rgba(201,169,110,.25);
+  }
+  .pulse::after { content:''; width: 26px; height: 26px; border-radius: 50%; background: var(--gold-bright); opacity: .8; }
+  @keyframes breathe { 0%,100% { transform: scale(1);} 50% { transform: scale(1.35);} }
+
+  textarea {
+    width: 100%; min-height: 96px; resize: vertical;
+    font-family: 'Jost', sans-serif; font-size: 17px; font-weight: 300; line-height: 1.6;
+    background: rgba(11,15,36,.6); color: var(--ink);
+    border: 1px solid var(--violet-soft); border-radius: 12px;
+    padding: 16px; margin-bottom: 12px;
+  }
+  textarea::placeholder { color: var(--violet-soft); }
+  textarea:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+  .hint { color: var(--violet-soft); font-size: 13.5px; text-align: center; margin-bottom: 24px; line-height: 1.5; }
+
+  .btn {
+    display: block; width: 100%;
+    font-family: 'Jost', sans-serif; font-size: 14px; letter-spacing: .2em; text-transform: uppercase; font-weight: 500;
+    padding: 17px 0; border-radius: 10px; cursor: pointer; text-align: center; text-decoration: none;
+    background: var(--gold); color: var(--navy); border: none;
+    transition: background .2s;
+  }
+  .btn:hover { background: var(--gold-bright); }
+  .btn:focus-visible { outline: 2px solid var(--ink); outline-offset: 3px; }
+  .btn-ghost { background: transparent; color: var(--ink); border: 1px solid var(--gold); margin-top: 12px; }
+  .btn-ghost:hover { background: rgba(201,169,110,.12); }
+
+  .recap {
+    background: rgba(18,23,58,.72); border: 1px solid rgba(201,169,110,.45);
+    border-radius: 14px; padding: 26px 24px; margin-bottom: 26px;
+  }
+  .recap .rlabel { font-size: 10.5px; letter-spacing: .28em; text-transform: uppercase; color: var(--violet-soft); font-weight: 600; margin-bottom: 5px; }
+  .recap .rtext { font-size: 16px; line-height: 1.55; margin-bottom: 16px; }
+  .recap .rtext.gold { font-family: 'Cormorant Garamond', serif; font-size: 21px; color: var(--gold-bright); margin-bottom: 0; }
+
+  .dots { display: flex; gap: 8px; justify-content: center; margin-bottom: 30px; }
+  .dots span { width: 8px; height: 8px; border-radius: 50%; border: 1px solid var(--violet-soft); }
+  .dots span.done { background: var(--gold-bright); border-color: var(--gold-bright); }
+
+  footer { text-align: center; padding: 18px 0 26px; font-size: 11.5px; letter-spacing: .2em; text-transform: uppercase; color: var(--violet-soft); }
+  footer a { color: var(--gold); text-decoration: none; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <p class="eyebrow">Shining Clarity Coaching</p>
+
+  <!-- START -->
+  <section class="screen on" id="s0">
+    <div class="pulse" aria-hidden="true"></div>
+    <h1>The Loop <em>Interrupt</em></h1>
+    <p class="sub">Spiraling right now? Good &mdash; you caught it while it's running. That's the hardest part, and you already did it.<br><br><strong>Three steps. About 60 seconds.</strong> Breathe with the circle while you're here.</p>
+    <button class="btn" onclick="go(1)">Interrupt It</button>
+  </section>
+
+  <!-- STEP 1 -->
+  <section class="screen" id="s1">
+    <div class="dots"><span class="done"></span><span></span><span></span></div>
+    <p class="steplabel">Step 1 of 3</p>
+    <h2>Name the thought</h2>
+    <p class="sub">One sentence. The loud version, exactly how it sounds in there. Naming it moves it from the part of your brain that panics to the part that observes.</p>
+    <textarea id="t1" placeholder="e.g. &quot;I'm going to mess this up like I always do.&quot;"></textarea>
+    <p class="hint">Nothing you type leaves this device.</p>
+    <button class="btn" onclick="go(2)">Next</button>
+  </section>
+
+  <!-- STEP 2 -->
+  <section class="screen" id="s2">
+    <div class="dots"><span class="done"></span><span class="done"></span><span></span></div>
+    <p class="steplabel">Step 2 of 3</p>
+    <h2>Run the camera test</h2>
+    <p class="sub">If a camera had been recording this situation &mdash; no sound track of your thoughts, just footage &mdash; what would it actually show? <strong>Facts only.</strong> No predictions, no mind reading.</p>
+    <textarea id="t2" placeholder="e.g. &quot;I sent the message ten minutes ago. No reply yet. That's all that's actually happened.&quot;"></textarea>
+    <button class="btn" onclick="go(3)">Next</button>
+  </section>
+
+  <!-- STEP 3 -->
+  <section class="screen" id="s3">
+    <div class="dots"><span class="done"></span><span class="done"></span><span class="done"></span></div>
+    <p class="steplabel">Step 3 of 3</p>
+    <h2>One accurate sentence</h2>
+    <p class="sub">Rewrite the thought using only what the camera saw. Not positive &mdash; <strong>accurate</strong>. If it's still uncomfortable, that's allowed. Accurate is enough to break the loop.</p>
+    <textarea id="t3" placeholder="e.g. &quot;I don't have a reply yet, and I don't actually know why. Everything else is a story I'm adding.&quot;"></textarea>
+    <button class="btn" onclick="finish()">Done</button>
+  </section>
+
+  <!-- DONE -->
+  <section class="screen" id="s4">
+    <h2>Loop <em>interrupted.</em></h2>
+    <p class="sub">The spiral runs on autopilot. You just took the wheel back &mdash; and every time you do this, the interrupt gets faster and the loop gets weaker. That's not a metaphor. That's how wiring works.</p>
+    <div class="recap" id="recap"></div>
+    <a class="btn" href="thought-record.html">Log It in Your Thought Record</a>
+    <button class="btn btn-ghost" onclick="reset()">Run It Again</button>
+    <a class="btn btn-ghost" href="https://shiningclaritycoaching.com">Start Here</a>
+  </section>
+</div>
+
+<footer><a href="https://shiningclaritycoaching.com">shiningclaritycoaching.com</a></footer>
+
+<script>
+function go(n){
+  document.querySelectorAll('.screen').forEach(s => s.classList.remove('on'));
+  document.getElementById('s'+n).classList.add('on');
+  window.scrollTo({top:0, behavior:'smooth'});
+}
+function esc(s){ const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+function finish(){
+  const t1 = document.getElementById('t1').value.trim();
+  const t2 = document.getElementById('t2').value.trim();
+  const t3 = document.getElementById('t3').value.trim();
+  let html = '';
+  if (t1) html += '<p class="rlabel">The thought</p><p class="rtext">“' + esc(t1) + '”</p>';
+  if (t2) html += '<p class="rlabel">What the camera saw</p><p class="rtext">' + esc(t2) + '</p>';
+  if (t3) html += '<p class="rlabel">The accurate version</p><p class="rtext gold">“' + esc(t3) + '”</p>';
+  if (!html) html = '<p class="rtext">You moved through it without writing &mdash; that works too. The steps count even when they stay in your head.</p>';
+  document.getElementById('recap').innerHTML = html;
+  go(4);
+}
+function reset(){
+  ['t1','t2','t3'].forEach(id => document.getElementById(id).value = '');
+  go(0);
+}
+</script>
+</body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -24,6 +24,7 @@
 <li><a href="/">Home</a></li>
 <li><a href="/about.html">About</a></li>
 <li><a href="/services.html">Services</a></li>
+<li><a href="/free-tools.html">Free Tools</a></li>
 <li><a href="/faq.html">FAQ</a></li>
 <li><a href="/contact.html">Contact</a></li>
 </ul>
@@ -36,6 +37,7 @@
   <a href="/" onclick="toggleMenu()">Home</a>
   <a href="/about.html" onclick="toggleMenu()">About</a>
   <a href="/services.html" onclick="toggleMenu()">Services</a>
+  <a href="/free-tools.html" onclick="toggleMenu()">Free Tools</a>
   <a href="/faq.html" onclick="toggleMenu()">FAQ</a>
   <a href="/contact.html" onclick="toggleMenu()">Contact</a>
   <a class="mobile-cta" href="/apply.html" onclick="toggleMenu()">Start Here</a>

--- a/services.html
+++ b/services.html
@@ -96,6 +96,7 @@
 <li><a href="/">Home</a></li>
 <li><a href="/about.html">About</a></li>
 <li><a href="/services.html">Services</a></li>
+<li><a href="/free-tools.html">Free Tools</a></li>
 <li><a href="/faq.html">FAQ</a></li>
 <li><a href="/contact.html">Contact</a></li>
 </ul>
@@ -108,6 +109,7 @@
   <a href="/" onclick="toggleMenu()">Home</a>
   <a href="/about.html" onclick="toggleMenu()">About</a>
   <a href="/services.html" onclick="toggleMenu()">Services</a>
+  <a href="/free-tools.html" onclick="toggleMenu()">Free Tools</a>
   <a href="/faq.html" onclick="toggleMenu()">FAQ</a>
   <a href="/contact.html" onclick="toggleMenu()">Contact</a>
   <a class="mobile-cta" href="/apply.html" onclick="toggleMenu()">Start Here</a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -44,6 +44,13 @@
   </url>
 
   <url>
+    <loc>https://shiningclaritycoaching.com/free-tools.html</loc>
+    <lastmod>2026-07-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
     <loc>https://shiningclaritycoaching.com/quiz.html</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>monthly</changefreq>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -79,6 +79,13 @@
   </url>
 
   <url>
+    <loc>https://shiningclaritycoaching.com/loop-interrupt.html</loc>
+    <lastmod>2026-07-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
     <loc>https://shiningclaritycoaching.com/terms.html</loc>
     <lastmod>2026-06-25</lastmod>
     <changefreq>yearly</changefreq>

--- a/terms.html
+++ b/terms.html
@@ -24,6 +24,7 @@
 <li><a href="/">Home</a></li>
 <li><a href="/about.html">About</a></li>
 <li><a href="/services.html">Services</a></li>
+<li><a href="/free-tools.html">Free Tools</a></li>
 <li><a href="/faq.html">FAQ</a></li>
 <li><a href="/contact.html">Contact</a></li>
 </ul>
@@ -36,6 +37,7 @@
   <a href="/" onclick="toggleMenu()">Home</a>
   <a href="/about.html" onclick="toggleMenu()">About</a>
   <a href="/services.html" onclick="toggleMenu()">Services</a>
+  <a href="/free-tools.html" onclick="toggleMenu()">Free Tools</a>
   <a href="/faq.html" onclick="toggleMenu()">FAQ</a>
   <a href="/contact.html" onclick="toggleMenu()">Contact</a>
   <a class="mobile-cta" href="/apply.html" onclick="toggleMenu()">Start Here</a>


### PR DESCRIPTION
## Summary
- Adds `free-tools.html`, a crawlable hub page (canonical URL, OG/Twitter tags) that lists all four tools: Find Your Loop, The Myths About Change, Spot the Loop, and The Thought Record.
- Adds a **"Free Tools"** nav link (desktop + mobile) across all 8 core site pages (Home, About, Services, FAQ, Contact, Apply, Terms, Privacy), between Services and FAQ.
- Adds `loop-interrupt.html`, a 60-second in-the-moment reset tool: name the spiraling thought, run a "camera test" to separate fact from story, rewrite one accurate sentence, then optionally continue into the Thought Record. Also linked as a 5th card on the Free Tools hub.
- Registers both new pages in `sitemap.xml`.

Note: this is a follow-up to #49 (Add Thought Record tool page), which merged before these additional commits were pushed to the same branch — reopening as a new PR since the branch's history now sits on top of the already-merged `main`.

## Test plan
- [ ] Visit `/free-tools.html` and confirm all 5 tool cards render and link correctly
- [ ] Confirm the "Free Tools" nav link appears (desktop + mobile menu) on Home, About, Services, FAQ, Contact, Apply, Terms, and Privacy
- [ ] Open `/loop-interrupt.html`, step through all 3 steps, confirm the recap screen shows what was typed
- [ ] Confirm "Log It in Your Thought Record" and "Run It Again" buttons work as expected


---
_Generated by [Claude Code](https://claude.ai/code/session_017gdeFQXPMCUAE3g7Ao7883)_